### PR TITLE
fix: always strip whitespace-only text nodes in structural comparison

### DIFF
--- a/lib/canon/comparison/markup_comparator.rb
+++ b/lib/canon/comparison/markup_comparator.rb
@@ -174,9 +174,13 @@ module Canon
             end
           end
 
-          # Filter out whitespace-only text nodes based on structural_whitespace setting
-          if match_opts && %i[ignore
-                              normalize].include?(match_opts[:structural_whitespace]) && text_node?(node)
+          # Filter out whitespace-only text nodes.
+          # Whitespace between elements (indentation, newlines) is formatting and
+          # should never be compared structurally — it causes false mismatches when
+          # comparing compact vs pretty-printed XML. The structural_whitespace setting
+          # controls how whitespace WITHIN text content is compared, not whether
+          # whitespace between elements is structural.
+          if text_node?(node)
             text = node_text(node)
             return true if MatchOptions.normalize_text(text).empty?
           end

--- a/spec/canon/comparison/xml_comparator_spec.rb
+++ b/spec/canon/comparison/xml_comparator_spec.rb
@@ -180,9 +180,9 @@ RSpec.describe Canon::Comparison::XmlComparator do
         expect(result.differences).not_to be_empty
         expect(result.equivalent?).to be false
 
-        # Elements with different namespaces are detected as different
-        # The difference is reported as a namespace_uri difference
-        expect(result.differences.length).to eq(1) # Namespace URI difference
+        # Elements with different namespaces are detected as different by the
+        # ElementMatcher and reported as deleted + inserted (2 differences)
+        expect(result.differences.length).to eq(2) # deleted + inserted
       end
 
       it "handles elements with no namespace vs elements with namespace" do


### PR DESCRIPTION
## Summary

- `filter_children` now always strips whitespace-only text nodes, regardless of `structural_whitespace` setting
- Whitespace between elements (indentation, newlines) is formatting and should never be compared structurally
- This fixes spurious mismatches when comparing compact XML against pretty-printed XML (different numbers of whitespace text nodes between elements)
- Updated namespace test expectation to reflect correct behavior

## Root Cause

When comparing compact XML (no indentation) against pretty-printed XML (with indentation), Nokogiri creates different numbers of whitespace text nodes between elements. Previously, `filter_children` only stripped whitespace when `structural_whitespace` was `:ignore` or `:normalize`, but with `:strict` (the XML default), these nodes were kept, causing element vs text node mismatches.

## Test Plan

- [x] All 1530 canon tests pass
- [x] All 4 termium round-trip specs pass