### PR TITLE
fix: strip whitespace from YAML string before parsing

### DIFF
--- a/lib/canon/comparison/yaml_comparator.rb
+++ b/lib/canon/comparison/yaml_comparator.rb
@@ -85,7 +85,7 @@ module Canon
         def parse_yaml(obj)
           return obj unless obj.is_a?(String)
 
-          YAML.safe_load(obj, aliases: true)
+          YAML.safe_load(obj.strip, aliases: true)
         end
       end
     end

--- a/spec/canon/comparison/yaml_comparator_spec.rb
+++ b/spec/canon/comparison/yaml_comparator_spec.rb
@@ -245,6 +245,41 @@ RSpec.describe Canon::Comparison::YamlComparator do
       end
     end
 
+    context "with leading/trailing whitespace" do
+      it "handles YAML with leading whitespace before document start" do
+        yaml1 = " ---\nkey: value\n"
+        yaml2 = "---\nkey: value\n"
+
+        expect(described_class.equivalent?(yaml1, yaml2)).to be true
+      end
+
+      it "handles YAML with trailing whitespace" do
+        yaml1 = "key: value\n  "
+        yaml2 = "key: value"
+
+        expect(described_class.equivalent?(yaml1, yaml2)).to be true
+      end
+
+      it "handles heredoc-style YAML with inconsistent indentation" do
+        yaml1 = <<~YAML
+           ---
+          key: value
+          list:
+          - item1
+          - item2
+        YAML
+        yaml2 = <<~YAML
+          ---
+          key: value
+          list:
+          - item1
+          - item2
+        YAML
+
+        expect(described_class.equivalent?(yaml1, yaml2)).to be true
+      end
+    end
+
     context "with Ruby objects" do
       it "handles pre-parsed Ruby hashes" do
         obj1 = { "key" => "value" }


### PR DESCRIPTION
## Summary

- FormatDetector.detect_string_uncached applies str.strip before checking trimmed.start_with?("---"), but YamlComparator.parse_yaml passes the raw unstripped string to YAML.safe_load. This means a string can be auto-detected as valid YAML but then fail to parse with Psych::SyntaxError.
- This is especially relevant for the be_equivalent_to matcher (new in 0.2.0) which auto-detects format and commonly receives heredoc strings with leading/trailing whitespace.
- Adds .strip to parse_yaml to match the detector behavior, plus tests for the whitespace scenarios.

## Test plan

- Added 3 new tests in yaml_comparator_spec.rb covering leading whitespace before ---, trailing whitespace, and heredoc-style inconsistent indentation
- All 28 YAML comparator tests pass
- Verified fix resolves the downstream failure in metanorma/metanorma