### PR TITLE
fix: strip whitespace-only text nodes for pre-parsed HTML5 inputs: #89

### DIFF
--- a/docs/features/match-options/html-policies.adoc
+++ b/docs/features/match-options/html-policies.adoc
@@ -226,6 +226,9 @@ Canon::Comparison.equivalent?(html1, html2, preprocessing: :rendered)
 Pretty-prints before comparison:
 - Consistent indentation
 - One element per line
+- Whitespace-only text nodes in strip-context elements (e.g. `<div>`) are
+  removed after formatting, so differences in structural whitespace between
+  elements do not produce false normative differences
 - Good for visual diffs
 
 [source,ruby]

--- a/lib/canon/comparison/html_comparator.rb
+++ b/lib/canon/comparison/html_comparator.rb
@@ -393,12 +393,17 @@ module Canon
               end
             end
 
-            # For :rendered preprocessing with Nokogiri nodes
-            if preprocessing == :rendered
-              # Normalize and return
+            # For preprocessing modes that require whitespace filtering,
+            # apply the same post-parsing normalization used for string inputs.
+            # This is needed because dom_diff() pre-parses HTML5 strings into
+            # Nokogiri fragments before calling HtmlComparator, bypassing the
+            # string-input path where these filters are normally applied.
+            if %i[normalize format rendered].include?(preprocessing)
               frag = node.is_a?(Nokogiri::XML::DocumentFragment) ? node : Nokogiri::XML.fragment(node.to_html)
               normalize_html_style_script_comments(frag)
-              normalize_rendered_whitespace(frag, match_opts)
+              if preprocessing == :rendered
+                normalize_rendered_whitespace(frag, match_opts)
+              end
               remove_whitespace_only_text_nodes(frag)
               return frag
             end

--- a/spec/canon/comparison/html_comparator_spec.rb
+++ b/spec/canon/comparison/html_comparator_spec.rb
@@ -294,6 +294,73 @@ RSpec.describe Canon::Comparison::HtmlComparator do
                                              preprocessing: :format)).to be true
         end
       end
+
+      describe "whitespace in strip-context elements with pre-parsed HTML5" do
+        # When dom_diff() pre-parses HTML5 strings into Nokogiri fragments,
+        # the Nokogiri-node path in parse_node must still strip
+        # whitespace-only text nodes in :strip context elements like <div>.
+        # Without this, whitespace differences like:
+        #   <div class="ol_wrap">\n  <ol>  vs  <div class="ol_wrap"><ol>
+        # are incorrectly reported as normative.
+
+        let(:html_with_ws) do
+          <<~HTML
+            <li id="A0b">
+              <p id="_">Level 1</p>
+              <div class="ol_wrap">
+                <ol type="1" id="A1">
+                  <li id="A1a"><p id="_">Level 2</p></li>
+                </ol>
+              </div>
+            </li>
+          HTML
+        end
+
+        let(:html_without_ws) do
+          <<~HTML
+            <li id="A0b">
+              <p id="_">Level 1</p>
+              <div class="ol_wrap"><ol type="1" id="A1">
+                <li id="A1a"><p id="_">Level 2</p></li>
+              </ol></div>
+            </li>
+          HTML
+        end
+
+        it "ignores whitespace-only text nodes in div with :format preprocessing" do
+          expect(described_class.equivalent?(
+                   html_with_ws, html_without_ws,
+                   format: :html5, preprocessing: :format
+                 )).to be true
+        end
+
+        it "ignores whitespace-only text nodes in div with :normalize preprocessing" do
+          expect(described_class.equivalent?(
+                   html_with_ws, html_without_ws,
+                   format: :html5, preprocessing: :normalize
+                 )).to be true
+        end
+
+        it "reports no normative diffs in verbose mode with :format preprocessing" do
+          result = described_class.equivalent?(
+            html_with_ws, html_without_ws,
+            format: :html5, preprocessing: :format, verbose: true
+          )
+          normative = result.differences.select(&:normative?)
+          expect(normative).to be_empty
+        end
+
+        it "works through the full matcher path with metanorma profile options" do
+          # This reproduces the exact options that the RSpec matcher builds
+          # from the metanorma config profile
+          result = Canon::Comparison.equivalent?(
+            html_with_ws, html_without_ws,
+            verbose: true, global_profile: :spec_friendly,
+            preprocessing: :format, diff_algorithm: :dom, format: :html5
+          )
+          expect(result.equivalent?).to be true
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
When dom_diff() pre-parses HTML5 strings into Nokogiri fragments before passing them to HtmlComparator, the Nokogiri-node path in parse_node returned them as-is, skipping the whitespace filtering that the string-input path applies. This caused whitespace-only text nodes in strip-context elements (e.g. `<div>`) to be reported as false normative differences when using :format or :normalize preprocessing.

Extend the pre-parsed node path to call remove_whitespace_only_text_nodes for :normalize and :format preprocessing, matching the existing behavior for :rendered and the string-input path.

Fixes #89