### PR TITLE
feat: improve semantic diff report readability for whitespace differences

### DIFF
--- a/docs/advanced/verbose-mode-architecture.adoc
+++ b/docs/advanced/verbose-mode-architecture.adoc
@@ -130,9 +130,32 @@ Each difference displays:
 * **Status indicator**: `[NORMATIVE]` (green) or `[INFORMATIVE]` (yellow)
 * **Dimension**: Which aspect differs (colorized in magenta)
 * **Location**: XPath for XML/HTML, path for JSON/YAML (colorized in blue)
+* **Reason**: When the reason contains visualized whitespace characters (░),
+  it is split across two lines with the before and after text vertically
+  aligned for easier visual comparison:
++
+[source]
+----
+Reason:  Text: "░░term2░definition░░"
+          vs.: "░term2░definition░"
+----
++
+When no visualized whitespace is present, the reason remains a single line.
 * **Expected section**: What was in File 1 (red heading, bold)
 * **Actual section**: What was in File 2 (green heading, bold)
 * **Changes summary**: Actionable description of the difference (yellow, bold)
+
+When both the Expected and Actual values are short (under 30 characters), they
+are rendered as compact single lines with aligned colons for succinctness:
+
+[source]
+----
+⊖ Expected (File 1): "term2 definition"
+⊕ Actual (File 2)  : "term2 definition"
+----
+
+For longer values, they appear on separate lines with no blank line between
+them.
 
 === Dimension-specific formats
 

--- a/lib/canon/diff_formatter/diff_detail_formatter.rb
+++ b/lib/canon/diff_formatter/diff_detail_formatter.rb
@@ -14,6 +14,9 @@ module Canon
     # Formats dimension-specific detail for individual differences
     # Provides actionable, colorized output showing exactly what changed
     module DiffDetailFormatter
+      ANSI_ESCAPE = /\e\[[0-9;]*m/
+      COMPACT_DETAIL_MAX = 30
+
       class << self
         # Format all differences as a semantic diff report
         #
@@ -127,9 +130,7 @@ compact: false, expand_difference: false)
 
           # show reason if available
           if diff.respond_to?(:reason) && diff.reason
-            output << "#{colorize('Reason:', :cyan, use_color,
-                                  bold: true)}  #{colorize(diff.reason,
-                                                           :yellow, use_color)}"
+            format_reason_line(output, diff.reason, use_color)
           end
           output << ""
 
@@ -138,13 +139,7 @@ compact: false, expand_difference: false)
             diff, use_color, compact: compact, expand_difference: expand_difference
           )
 
-          output << colorize("⊖ Expected (File 1):", :red, use_color,
-                             bold: true)
-          output << "   #{detail1}"
-          output << ""
-          output << colorize("⊕ Actual (File 2):", :green, use_color,
-                             bold: true)
-          output << "   #{detail2}"
+          format_expected_actual(output, detail1, detail2, use_color)
 
           if changes && !changes.empty?
             output << ""
@@ -180,6 +175,52 @@ compact: false, expand_difference: false)
           ].join("\n")
 
           colorize(error_msg, :red, use_color, bold: true)
+        end
+
+        # Format the Reason line. When the reason contains visualized
+        # spaces (░), split into two vertically-aligned lines so the
+        # before/after text can be compared visually.
+        def format_reason_line(output, reason_text, use_color)
+          if reason_text.include?("\u2591") &&
+              reason_text.match?(/\A(Text|whitespace): .*\bvs\b/)
+            parts = reason_text.split(" vs ", 2)
+            if parts.length == 2
+              output << "#{colorize('Reason:', :cyan, use_color,
+                                    bold: true)}  #{colorize(parts[0],
+                                                             :yellow, use_color)}"
+              output << "#{' ' * 10}#{colorize("vs.: #{parts[1]}",
+                                               :yellow, use_color)}"
+              return
+            end
+          end
+          output << "#{colorize('Reason:', :cyan, use_color,
+                                bold: true)}  #{colorize(reason_text,
+                                                         :yellow, use_color)}"
+        end
+
+        # Format the Expected/Actual block. Short values (both under 30
+        # chars) are rendered as compact single lines with aligned colons;
+        # longer values use the multi-line layout without a blank line gap.
+        def format_expected_actual(output, detail1, detail2, use_color)
+          plain1 = detail1.gsub(ANSI_ESCAPE, "")
+          plain2 = detail2.gsub(ANSI_ESCAPE, "")
+
+          if plain1.length < COMPACT_DETAIL_MAX &&
+              plain2.length < COMPACT_DETAIL_MAX
+            lbl1 = colorize("\u2296 Expected (File 1)", :red, use_color,
+                            bold: true)
+            lbl2 = colorize("\u2295 Actual (File 2)  ", :green, use_color,
+                            bold: true)
+            output << "#{lbl1}: #{detail1}"
+            output << "#{lbl2}: #{detail2}"
+          else
+            output << colorize("\u2296 Expected (File 1):", :red, use_color,
+                               bold: true)
+            output << "   #{detail1}"
+            output << colorize("\u2295 Actual (File 2):", :green, use_color,
+                               bold: true)
+            output << "   #{detail2}"
+          end
         end
 
         # Helper: Colorize text

--- a/spec/canon/diff_formatter/diff_detail_formatter_spec.rb
+++ b/spec/canon/diff_formatter/diff_detail_formatter_spec.rb
@@ -543,6 +543,112 @@ RSpec.describe "DiffDetailFormatter helpers" do
     end
   end
 
+  # ── Issue #91: diff report readability for whitespace differences ──────────
+
+  describe Canon::DiffFormatter::DiffDetailFormatter, "Reason line formatting (Issue #91)" do
+    def build_diff(reason:, text1: "a", text2: "b")
+      n1 = Canon::Xml::Nodes::TextNode.new(value: text1)
+      n2 = Canon::Xml::Nodes::TextNode.new(value: text2)
+      node = Canon::Diff::DiffNode.new(
+        node1: n1, node2: n2,
+        dimension: :text_content, reason: reason
+      )
+      node.normative = true
+      node
+    end
+
+    it "splits reason into two aligned lines when visualized spaces are present" do
+      reason = "Text: \"\u2591\u2591term2\u2591def\u2591\u2591\" " \
+               "vs \"\u2591term2\u2591def\u2591\""
+      diff = build_diff(reason: reason)
+      report = described_class.format_report([diff], use_color: false)
+      lines = report.lines.map(&:chomp)
+
+      reason_line = lines.find { |l| l.include?("Reason:") }
+      vs_idx = lines.index(reason_line) + 1
+
+      expect(reason_line).to include("Text:")
+      expect(reason_line).not_to include(" vs ")
+      expect(lines[vs_idx]).to match(/\A\s+vs\.:/)
+    end
+
+    it "keeps the reason as a single line when no visualized spaces" do
+      diff = build_diff(reason: "only in first: class, id")
+      report = described_class.format_report([diff], use_color: false)
+      lines = report.lines.map(&:chomp)
+
+      reason_line = lines.find { |l| l.include?("Reason:") }
+      expect(reason_line).to include("only in first: class, id")
+
+      vs_idx = lines.index(reason_line) + 1
+      expect(lines[vs_idx]).not_to match(/vs\.:/i)
+    end
+  end
+
+  describe Canon::DiffFormatter::DiffDetailFormatter, "Expected/Actual layout (Issue #91)" do
+    def build_diff(text1:, text2:)
+      n1 = Canon::Xml::Nodes::TextNode.new(value: text1)
+      n2 = Canon::Xml::Nodes::TextNode.new(value: text2)
+      node = Canon::Diff::DiffNode.new(
+        node1: n1, node2: n2,
+        dimension: :text_content, reason: "Text: differs"
+      )
+      node.normative = true
+      node
+    end
+
+    context "when both values are short" do
+      it "renders Expected and Actual as compact single lines" do
+        diff = build_diff(text1: "hello", text2: "world")
+        report = described_class.format_report([diff], use_color: false)
+        lines = report.lines.map(&:chomp)
+
+        expected_line = lines.find { |l| l.include?("Expected (File 1)") }
+        actual_line = lines.find { |l| l.include?("Actual (File 2)") }
+
+        expect(expected_line).to match(/Expected \(File 1\).*:.*"hello"/)
+        expect(actual_line).to match(/Actual \(File 2\).*:.*"world"/)
+      end
+
+      it "has no blank line between Expected and Actual" do
+        diff = build_diff(text1: "hello", text2: "world")
+        report = described_class.format_report([diff], use_color: false)
+        lines = report.lines.map(&:chomp)
+
+        expected_idx = lines.index { |l| l.include?("Expected (File 1)") }
+        actual_idx = lines.index { |l| l.include?("Actual (File 2)") }
+
+        expect(actual_idx).to eq(expected_idx + 1)
+      end
+    end
+
+    context "when a value is 30+ chars" do
+      let(:long_text) { "this is a value that exceeds thirty characters easily" }
+
+      it "renders values on separate indented lines" do
+        diff = build_diff(text1: "short", text2: long_text)
+        report = described_class.format_report([diff], use_color: false)
+        lines = report.lines.map(&:chomp)
+
+        expected_idx = lines.index { |l| l.include?("Expected (File 1)") }
+        expect(lines[expected_idx]).to include("Expected (File 1):")
+        expect(lines[expected_idx + 1]).to match(/\A\s+"short"/)
+      end
+
+      it "has no blank line between Expected and Actual blocks" do
+        diff = build_diff(text1: "short", text2: long_text)
+        report = described_class.format_report([diff], use_color: false)
+        lines = report.lines.map(&:chomp)
+
+        expected_idx = lines.index { |l| l.include?("Expected (File 1)") }
+        actual_idx = lines.index { |l| l.include?("Actual (File 2)") }
+
+        # Expected label, Expected value, Actual label (no blank line)
+        expect(actual_idx).to eq(expected_idx + 2)
+      end
+    end
+  end
+
   describe "Issue #52 scenario: text content with NBSP difference" do
     it "preserves NBSP in text content for diff display" do
       # This test verifies the fix for:


### PR DESCRIPTION
## Summary

- Split the `Reason:` line into two vertically-aligned lines when visualized spaces (░) are present, so before/after text can be compared visually
- Remove the blank line between Expected and Actual blocks
- Render Expected/Actual as compact single lines with aligned colons when both values are under 30 characters

Fixes #91

## Test plan

- [x] 6 new spec tests covering all three behaviors
- [x] Full suite passes (2008 examples, 0 failures)
- [x] Rubocop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)