### PR TITLE
refactor: clean up element_structure normative model, improve MISSING_NODE reason messages

### DIFF
--- a/docs/advanced/diff-classification.adoc
+++ b/docs/advanced/diff-classification.adoc
@@ -253,6 +253,19 @@ result = Canon::Comparison.equivalent?(xml1, xml2)
   - Comment differences tracked but don't affect equivalence
   - Default for HTML (comments are presentational)
 
+==== Element Structure
+
+`element_structure` is a derived dimension — produced by comparators when children
+differ structurally (insertions, deletions, name changes). It is not a user-configurable
+match dimension but follows the same normative rule as all general dimensions:
+
+* **Default (no explicit behavior)** → Normative
+  - Structural differences (added/removed/renamed elements) affect equivalence
+
+* **`:ignore` behavior** → Informative
+  - Structural differences tracked but don't affect equivalence
+  - Useful for content-only comparisons where wrapper elements don't matter
+
 .Example: Comment handling
 ====
 [source,ruby]
@@ -405,6 +418,8 @@ The classification system uses three main classes:
   - `normative_dimension?(dimension)` - Is this dimension normative?
   - `affects_equivalence?(dimension)` - Does this dimension affect equivalence?
   - `supports_formatting_detection?(dimension)` - Can this dimension have formatting-only diffs?
+  - Normative rules: `structural_whitespace` requires `:strict` for normative status;
+    all other dimensions are normative unless behavior is `:ignore`
 
 * **`DiffClassifier`** - Orchestrates classification using the above
   - First checks `XmlSerializationFormatter` for serialization formatting

--- a/lib/canon/comparison/compare_profile.rb
+++ b/lib/canon/comparison/compare_profile.rb
@@ -51,12 +51,13 @@ module Canon
       #
       # This is used by DiffClassifier to determine the normative flag.
       #
+      # Normative rules by dimension:
+      # - structural_whitespace: only :strict is normative (:normalize and :ignore are informative)
+      # - all other dimensions: normative unless behavior is :ignore
+      #
       # @param dimension [Symbol] The match dimension to check
       # @return [Boolean] true if normative, false if informative
       def normative_dimension?(dimension)
-        # Element structure changes are ALWAYS normative
-        return true if dimension == :element_structure
-
         # Structural whitespace with :normalize or :ignore behavior is INFORMATIVE
         # Only :strict mode makes whitespace normative
         if dimension == :structural_whitespace
@@ -64,7 +65,7 @@ module Canon
           return behavior == :strict
         end
 
-        # For other dimensions, if behavior affects equivalence, it's normative
+        # For all other dimensions, normative if behavior affects equivalence
         affects_equivalence?(dimension)
       end
 

--- a/lib/canon/comparison/markup_comparator.rb
+++ b/lib/canon/comparison/markup_comparator.rb
@@ -306,7 +306,11 @@ module Canon
           end
 
           # Default reason - can be overridden in subclasses
-          "#{diff1} vs #{diff2}"
+          if diff1 == Canon::Comparison::MISSING_NODE && diff2 == Canon::Comparison::MISSING_NODE
+            "element structure mismatch (children differ)"
+          else
+            "#{diff1} vs #{diff2}"
+          end
         end
 
         # Build a clear reason message for attribute presence differences

--- a/lib/canon/comparison/xml_comparator.rb
+++ b/lib/canon/comparison/xml_comparator.rb
@@ -631,7 +631,11 @@ differences)
             return "Attribute order changed: [#{attrs1.join(', ')}] → [#{attrs2.join(', ')}]"
           end
 
-          "#{diff1} vs #{diff2}"
+          if diff1 == Canon::Comparison::MISSING_NODE && diff2 == Canon::Comparison::MISSING_NODE
+            "element structure mismatch (children differ)"
+          else
+            "#{diff1} vs #{diff2}"
+          end
         end
 
         # Build a clear reason message for attribute value differences

--- a/lib/canon/comparison/xml_comparator/diff_node_builder.rb
+++ b/lib/canon/comparison/xml_comparator/diff_node_builder.rb
@@ -85,7 +85,11 @@ module Canon
         end
 
         # Default reason
-        "#{diff1} vs #{diff2}"
+        if diff1 == Canon::Comparison::MISSING_NODE && diff2 == Canon::Comparison::MISSING_NODE
+          "element structure mismatch (children differ)"
+        else
+          "#{diff1} vs #{diff2}"
+        end
       end
 
       # Enrich DiffNode with canonical path, serialized content, and attributes

--- a/spec/canon/comparison/compare_profile_spec.rb
+++ b/spec/canon/comparison/compare_profile_spec.rb
@@ -46,30 +46,49 @@ RSpec.describe Canon::Comparison::CompareProfile do
   end
 
   describe "#normative_dimension?" do
-    context "for element_structure dimension" do
-      it "always returns true regardless of behavior" do
-        match_opts = { element_structure: :ignore }
-        profile = described_class.new(match_opts)
+    context "when dimension affects equivalence (behavior is not :ignore)" do
+      it "returns true for text_content with :strict" do
+        profile = described_class.new({ text_content: :strict })
+        expect(profile.normative_dimension?(:text_content)).to be true
+      end
 
+      it "returns true for element_structure with :strict" do
+        profile = described_class.new({ element_structure: :strict })
+        expect(profile.normative_dimension?(:element_structure)).to be true
+      end
+
+      it "returns true for element_structure by default" do
+        profile = described_class.new({})
         expect(profile.normative_dimension?(:element_structure)).to be true
       end
     end
 
-    context "when dimension affects equivalence" do
-      it "returns true" do
-        match_opts = { text_content: :strict }
-        profile = described_class.new(match_opts)
+    context "when dimension does not affect equivalence (behavior is :ignore)" do
+      it "returns false for comments with :ignore" do
+        profile = described_class.new({ comments: :ignore })
+        expect(profile.normative_dimension?(:comments)).to be false
+      end
 
-        expect(profile.normative_dimension?(:text_content)).to be true
+      it "returns false for element_structure with :ignore" do
+        profile = described_class.new({ element_structure: :ignore })
+        expect(profile.normative_dimension?(:element_structure)).to be false
       end
     end
 
-    context "when dimension does not affect equivalence" do
-      it "returns false" do
-        match_opts = { comments: :ignore }
-        profile = described_class.new(match_opts)
+    context "for structural_whitespace (special rule)" do
+      it "returns true only for :strict" do
+        profile = described_class.new({ structural_whitespace: :strict })
+        expect(profile.normative_dimension?(:structural_whitespace)).to be true
+      end
 
-        expect(profile.normative_dimension?(:comments)).to be false
+      it "returns false for :normalize" do
+        profile = described_class.new({ structural_whitespace: :normalize })
+        expect(profile.normative_dimension?(:structural_whitespace)).to be false
+      end
+
+      it "returns false for :ignore" do
+        profile = described_class.new({ structural_whitespace: :ignore })
+        expect(profile.normative_dimension?(:structural_whitespace)).to be false
       end
     end
   end
@@ -129,6 +148,18 @@ RSpec.describe Canon::Comparison::CompareProfile do
       expect(profile.affects_equivalence?(:text_content)).to be true
       expect(profile.normative_dimension?(:comments)).to be false
       expect(profile.normative_dimension?(:text_content)).to be true
+    end
+
+    it "defaults element_structure to normative when not in resolved options" do
+      # element_structure is a derived dimension, not in match_dimensions,
+      # so ResolvedMatchOptions returns nil for it — should still default to normative
+      resolved_opts = Canon::Comparison::ResolvedMatchOptions.new(
+        { comments: :ignore },
+        format: :xml,
+      )
+      profile = described_class.new(resolved_opts)
+
+      expect(profile.normative_dimension?(:element_structure)).to be true
     end
   end
 end

--- a/spec/canon/comparison/html_compare_profile_spec.rb
+++ b/spec/canon/comparison/html_compare_profile_spec.rb
@@ -142,9 +142,14 @@ RSpec.describe Canon::Comparison::HtmlCompareProfile do
   end
 
   describe "#normative_dimension?" do
-    it "returns true for element_structure (always normative)" do
+    it "returns true for element_structure by default" do
       profile = described_class.new({})
       expect(profile.normative_dimension?(:element_structure)).to be true
+    end
+
+    it "returns false for element_structure when :ignore" do
+      profile = described_class.new({ element_structure: :ignore })
+      expect(profile.normative_dimension?(:element_structure)).to be false
     end
 
     it "returns false for comments (not normative in HTML)" do

--- a/spec/canon/diff/diff_classifier_spec.rb
+++ b/spec/canon/diff/diff_classifier_spec.rb
@@ -237,30 +237,61 @@ RSpec.describe Canon::Diff::DiffClassifier do
     end
 
     describe "element_structure dimension classification" do
-      let(:match_options_hash) { {} }
-      let(:match_options) do
-        Canon::Comparison::ResolvedMatchOptions.new(
-          match_options_hash,
-          format: :xml,
-        )
+      context "with default options" do
+        let(:match_options_hash) { {} }
+        let(:match_options) do
+          Canon::Comparison::ResolvedMatchOptions.new(
+            match_options_hash,
+            format: :xml,
+          )
+        end
+        let(:classifier) { described_class.new(match_options) }
+
+        it "classifies as normative by default" do
+          elem1 = double("Element", name: "div")
+          elem2 = double("Element", name: "span")
+
+          diff_node = Canon::Diff::DiffNode.new(
+            node1: elem1,
+            node2: elem2,
+            dimension: :element_structure,
+            reason: "element structure differs",
+          )
+
+          classifier.classify(diff_node)
+
+          expect(diff_node.formatting?).to be false
+          expect(diff_node.normative?).to be true
+        end
       end
-      let(:classifier) { described_class.new(match_options) }
 
-      it "always classifies as normative" do
-        elem1 = double("Element", name: "div")
-        elem2 = double("Element", name: "span")
+      context "with element_structure: :ignore" do
+        let(:match_options_hash) { { element_structure: :ignore } }
+        let(:match_options) do
+          Canon::Comparison::ResolvedMatchOptions.new(
+            match_options_hash,
+            format: :xml,
+          )
+        end
+        let(:classifier) { described_class.new(match_options) }
 
-        diff_node = Canon::Diff::DiffNode.new(
-          node1: elem1,
-          node2: elem2,
-          dimension: :element_structure,
-          reason: "element structure differs",
-        )
+        it "classifies as non-normative when behavior is :ignore" do
+          elem1 = double("Element", name: "div")
+          elem2 = double("Element", name: "span")
 
-        classifier.classify(diff_node)
+          diff_node = Canon::Diff::DiffNode.new(
+            node1: elem1,
+            node2: elem2,
+            dimension: :element_structure,
+            reason: "element structure differs",
+          )
 
-        expect(diff_node.formatting?).to be false
-        expect(diff_node.normative?).to be true
+          classifier.classify(diff_node)
+
+          expect(diff_node.formatting?).to be false
+          expect(diff_node.normative?).to be false
+          expect(diff_node.informative?).to be true
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

- **Removed redundant `element_structure` special case** in `CompareProfile#normative_dimension?`. The branch was forcing `element_structure` to always be normative. The intended behavior (respect `:ignore` setting) is identical to the default `affects_equivalence?` path, so the branch was removed entirely. This produces a clean two-tier normative rule model:
  - `structural_whitespace`: only `:strict` is normative (special rule)
  - All other dimensions: normative unless `:ignore` (default)
- **Improved diff reason messages** when both sides are `MISSING_NODE` (children differ structurally): now says "element structure mismatch (children differ)" instead of the unhelpful "MISSING vs MISSING".
- **Updated specs** to cover `element_structure` with `:ignore` behavior through the full `DiffClassifier` → `CompareProfile` pipeline, including `ResolvedMatchOptions` integration for the derived dimension edge case.
- **Updated docs** (`diff-classification.adoc`) to document the normative rule model and `element_structure` as a derived dimension.

## Test plan

- [x] All 578 comparison/diff specs pass
- [x] `compare_profile_spec.rb` — `element_structure` tested in general normative contexts + `structural_whitespace` special rule tests added + `ResolvedMatchOptions` integration test
- [x] `diff_classifier_spec.rb` — element_structure tested for both default (normative) and `:ignore` (non-normative) through the full classifier pipeline
- [x] `html_compare_profile_spec.rb` — element_structure tested for default and `:ignore` cases