### PR TITLE
feat: config enum validation + element_structure diff display

### DIFF
--- a/lib/canon/config.rb
+++ b/lib/canon/config.rb
@@ -285,6 +285,7 @@ module Canon
       end
 
       def indent_type=(value)
+        DiffConfig.validate_config_value!(:pretty_printer_indent_type, value)
         @resolver.set_programmatic(:pretty_printer_indent_type, value)
       end
     end
@@ -292,6 +293,18 @@ module Canon
     # Diff configuration for output formatting
     class DiffConfig
       attr_reader :pretty_printer
+
+      # Valid values for enum-like configuration options
+      VALID_ENUM_VALUES = {
+        mode: %i[by_line by_object pretty_diff],
+        show_diffs: %i[all normative informative],
+        algorithm: %i[dom semantic],
+        display_preprocessing: %i[none pretty_print normalize_pretty_print c14n],
+        display_format: %i[raw canonical],
+        pretty_printer_indent_type: %i[space tab],
+        character_visualization: [true, false, :content_only],
+        theme: %i[light dark retro claude cyberpunk],
+      }.freeze
 
       def initialize(format = nil)
         @format = format
@@ -309,12 +322,26 @@ module Canon
 
         data.each do |key, value|
           sym_key = key.to_sym
-          @resolver.set_profile(sym_key, coerce_profile_value(sym_key, value))
+          coerced = coerce_profile_value(sym_key, value)
+          self.class.validate_config_value!(sym_key, coerced)
+          @resolver.set_profile(sym_key, coerced)
         end
       end
 
       def clear_profile!
         @resolver.clear_profile!
+      end
+
+      # Validate a config value against its allowed enum values
+      def self.validate_config_value!(key, value)
+        valid = VALID_ENUM_VALUES[key]
+        return unless valid
+
+        return if valid.include?(value)
+
+        raise ArgumentError,
+              "Invalid value #{value.inspect} for #{key}. " \
+              "Valid values: #{valid.map(&:inspect).join(', ')}"
       end
 
       # Accessors with ENV override support
@@ -323,6 +350,7 @@ module Canon
       end
 
       def mode=(value)
+        self.class.validate_config_value!(:mode, value)
         @resolver.set_programmatic(:mode, value)
       end
 
@@ -355,6 +383,7 @@ module Canon
       end
 
       def show_diffs=(value)
+        self.class.validate_config_value!(:show_diffs, value)
         @resolver.set_programmatic(:show_diffs, value)
       end
 
@@ -495,6 +524,7 @@ module Canon
       end
 
       def display_format=(value)
+        self.class.validate_config_value!(:display_format, value)
         @resolver.set_programmatic(:display_format, value)
       end
 
@@ -511,6 +541,7 @@ module Canon
       end
 
       def display_preprocessing=(value)
+        self.class.validate_config_value!(:display_preprocessing, value)
         @resolver.set_programmatic(:display_preprocessing, value)
       end
 
@@ -636,6 +667,7 @@ module Canon
       end
 
       def character_visualization=(value)
+        self.class.validate_config_value!(:character_visualization, value)
         @resolver.set_programmatic(:character_visualization, value)
       end
 
@@ -644,6 +676,7 @@ module Canon
       end
 
       def algorithm=(value)
+        self.class.validate_config_value!(:algorithm, value)
         @resolver.set_programmatic(:algorithm, value)
       end
 
@@ -653,6 +686,7 @@ module Canon
       end
 
       def theme=(value)
+        self.class.validate_config_value!(:theme, value)
         @resolver.set_programmatic(:theme, value)
       end
 

--- a/lib/canon/diff_formatter/diff_detail_formatter/dimension_formatter.rb
+++ b/lib/canon/diff_formatter/diff_detail_formatter/dimension_formatter.rb
@@ -23,8 +23,7 @@ expand_difference: false)
           when :namespace_declarations
             format_namespace_declarations_details(diff, use_color)
           when :element_structure
-            format_element_structure_details(diff, use_color,
-                                             expand_difference: expand_difference)
+            format_element_structure_details(diff, use_color)
           when :attribute_presence
             format_attribute_presence_details(diff, use_color)
           when :attribute_values
@@ -163,35 +162,66 @@ expand_difference: false)
 
         # Format element structure differences
         #
+        # Produces compact XML for both sides so the user can see attributes
+        # and text content, not just the tag name.  Handles nil nodes that
+        # arise from insertions/deletions.
+        #
         # @param diff [DiffNode, Hash] Difference node
         # @param use_color [Boolean] Whether to use colors
         # @return [Array] Tuple of [detail1, detail2, changes]
-        def self.format_element_structure_details(diff, use_color,
-expand_difference: false)
+        def self.format_element_structure_details(diff, use_color)
           require_relative "color_helper"
           require_relative "node_utils"
 
           node1 = extract_node1(diff)
           node2 = extract_node2(diff)
 
-          name1 = NodeUtils.get_element_name_for_display(node1)
-          name2 = NodeUtils.get_element_name_for_display(node2)
+          has1 = !node1.nil?
+          has2 = !node2.nil?
 
-          if expand_difference
-            display1 = NodeUtils.serialize_node_compact(node1)
-            display2 = NodeUtils.serialize_node_compact(node2)
-            detail1 = ColorHelper.colorize(display1, :red, use_color)
-            detail2 = ColorHelper.colorize(display2, :green, use_color)
+          if has1 && has2
+            # Both elements present — show compact XML for both
+            compact1 = NodeUtils.serialize_node_compact(node1)
+            compact2 = NodeUtils.serialize_node_compact(node2)
+            detail1 = ColorHelper.colorize(compact1, :red, use_color)
+            detail2 = ColorHelper.colorize(compact2, :green, use_color)
+
+            name1 = NodeUtils.get_element_name_for_display(node1)
+            name2 = NodeUtils.get_element_name_for_display(node2)
+
+            changes = if name1 == name2
+                        "Element <#{name1}> structure changed (children differ)"
+                      else
+                        build_structure_change_text(compact1, compact2,
+                                                    use_color)
+                      end
+          elsif has1
+            # Element removed
+            compact1 = NodeUtils.serialize_node_compact(node1)
+            detail1 = ColorHelper.colorize(compact1, :red, use_color)
+            detail2 = ColorHelper.colorize("(not present)", :green, use_color)
+            changes = "Element removed: #{ColorHelper.colorize(compact1, :red, use_color)}"
           else
-            detail1 = "<#{ColorHelper.colorize(name1, :red, use_color)}>"
-            detail2 = "<#{ColorHelper.colorize(name2, :green, use_color)}>"
+            # Element added
+            compact2 = NodeUtils.serialize_node_compact(node2)
+            detail1 = ColorHelper.colorize("(not present)", :red, use_color)
+            detail2 = ColorHelper.colorize(compact2, :green, use_color)
+            changes = "Element added: #{ColorHelper.colorize(compact2, :green, use_color)}"
           end
 
-          changes = "Element differs: #{ColorHelper.colorize(name1, :red,
-                                                             use_color)} → " \
-                    "#{ColorHelper.colorize(name2, :green, use_color)}"
-
           [detail1, detail2, changes]
+        end
+
+        # Build human-readable change text for element structure diffs
+        #
+        # @param display1 [String] Serialized expected element
+        # @param display2 [String] Serialized actual element
+        # @param use_color [Boolean] Whether to use colors
+        # @return [String] Change description
+        def self.build_structure_change_text(display1, display2, use_color)
+          "Element structure changed: " \
+            "#{ColorHelper.colorize(display1, :red, use_color)} → " \
+            "#{ColorHelper.colorize(display2, :green, use_color)}"
         end
 
         # Format attribute presence differences

--- a/spec/canon/config/diff_config_spec.rb
+++ b/spec/canon/config/diff_config_spec.rb
@@ -668,4 +668,149 @@ RSpec.describe Canon::Config::DiffConfig do
       expect(cfg.show_prettyprint_received).to be(true)
     end
   end
+
+  # ── Enum validation ─────────────────────────────────────────────────────────
+
+  describe "enum validation" do
+    describe ".validate_config_value!" do
+      it "accepts valid mode values" do
+        expect { described_class.validate_config_value!(:mode, :by_line) }.not_to raise_error
+        expect { described_class.validate_config_value!(:mode, :by_object) }.not_to raise_error
+        expect { described_class.validate_config_value!(:mode, :pretty_diff) }.not_to raise_error
+      end
+
+      it "rejects invalid mode values" do
+        expect { described_class.validate_config_value!(:mode, :foo) }
+          .to raise_error(ArgumentError, /Invalid value :foo for mode/)
+      end
+
+      it "accepts valid show_diffs values" do
+        expect { described_class.validate_config_value!(:show_diffs, :all) }.not_to raise_error
+        expect { described_class.validate_config_value!(:show_diffs, :normative) }.not_to raise_error
+        expect { described_class.validate_config_value!(:show_diffs, :informative) }.not_to raise_error
+      end
+
+      it "rejects invalid show_diffs values" do
+        expect { described_class.validate_config_value!(:show_diffs, :foo) }
+          .to raise_error(ArgumentError, /Invalid value :foo for show_diffs/)
+      end
+
+      it "accepts valid algorithm values" do
+        expect { described_class.validate_config_value!(:algorithm, :dom) }.not_to raise_error
+        expect { described_class.validate_config_value!(:algorithm, :semantic) }.not_to raise_error
+      end
+
+      it "rejects invalid algorithm values" do
+        expect { described_class.validate_config_value!(:algorithm, :foo) }
+          .to raise_error(ArgumentError, /Invalid value :foo for algorithm/)
+      end
+
+      it "accepts valid theme values" do
+        %i[light dark retro claude cyberpunk].each do |val|
+          expect { described_class.validate_config_value!(:theme, val) }.not_to raise_error
+        end
+      end
+
+      it "rejects invalid theme values" do
+        expect { described_class.validate_config_value!(:theme, :foo) }
+          .to raise_error(ArgumentError, /Invalid value :foo for theme/)
+      end
+
+      it "accepts valid indent_type values" do
+        expect { described_class.validate_config_value!(:pretty_printer_indent_type, :space) }.not_to raise_error
+        expect { described_class.validate_config_value!(:pretty_printer_indent_type, :tab) }.not_to raise_error
+      end
+
+      it "rejects invalid indent_type values" do
+        expect { described_class.validate_config_value!(:pretty_printer_indent_type, :foo) }
+          .to raise_error(ArgumentError, /Invalid value :foo for pretty_printer_indent_type/)
+      end
+
+      it "accepts valid character_visualization values" do
+        expect { described_class.validate_config_value!(:character_visualization, true) }.not_to raise_error
+        expect { described_class.validate_config_value!(:character_visualization, false) }.not_to raise_error
+        expect { described_class.validate_config_value!(:character_visualization, :content_only) }.not_to raise_error
+      end
+
+      it "rejects invalid character_visualization values" do
+        expect { described_class.validate_config_value!(:character_visualization, :foo) }
+          .to raise_error(ArgumentError, /Invalid value :foo for character_visualization/)
+      end
+
+      it "accepts valid display_preprocessing values" do
+        expect { described_class.validate_config_value!(:display_preprocessing, :none) }.not_to raise_error
+        expect { described_class.validate_config_value!(:display_preprocessing, :pretty_print) }.not_to raise_error
+        expect { described_class.validate_config_value!(:display_preprocessing, :normalize_pretty_print) }.not_to raise_error
+        expect { described_class.validate_config_value!(:display_preprocessing, :c14n) }.not_to raise_error
+      end
+
+      it "accepts valid display_format values" do
+        expect { described_class.validate_config_value!(:display_format, :raw) }.not_to raise_error
+        expect { described_class.validate_config_value!(:display_format, :canonical) }.not_to raise_error
+      end
+
+      it "rejects keys with no defined enum (no-op)" do
+        expect { described_class.validate_config_value!(:max_file_size, 99) }.not_to raise_error
+        expect { described_class.validate_config_value!(:context_lines, 5) }.not_to raise_error
+      end
+    end
+
+    describe "setter validation" do
+      it "mode= raises on invalid value" do
+        expect { config.mode = :foo }
+          .to raise_error(ArgumentError, /Invalid value :foo for mode/)
+      end
+
+      it "show_diffs= raises on invalid value" do
+        expect { config.show_diffs = :foo }
+          .to raise_error(ArgumentError, /Invalid value :foo for show_diffs/)
+      end
+
+      it "algorithm= raises on invalid value" do
+        expect { config.algorithm = :foo }
+          .to raise_error(ArgumentError, /Invalid value :foo for algorithm/)
+      end
+
+      it "theme= raises on invalid value" do
+        expect { config.theme = :foo }
+          .to raise_error(ArgumentError, /Invalid value :foo for theme/)
+      end
+
+      it "pretty_printer.indent_type= raises on invalid value" do
+        expect { config.pretty_printer.indent_type = :foo }
+          .to raise_error(ArgumentError, /Invalid value :foo for pretty_printer_indent_type/)
+      end
+
+      it "display_preprocessing= raises on invalid value" do
+        expect { config.display_preprocessing = :foo }
+          .to raise_error(ArgumentError, /Invalid value :foo for display_preprocessing/)
+      end
+
+      it "display_format= raises on invalid value" do
+        expect { config.display_format = :foo }
+          .to raise_error(ArgumentError, /Invalid value :foo for display_format/)
+      end
+
+      it "character_visualization= raises on invalid value" do
+        expect { config.character_visualization = :foo }
+          .to raise_error(ArgumentError, /Invalid value :foo for character_visualization/)
+      end
+
+      it "apply_profile_data raises on invalid value" do
+        expect { config.apply_profile_data({ mode: :foo }) }
+          .to raise_error(ArgumentError, /Invalid value :foo for mode/)
+      end
+
+      it "setters accept valid values without raising" do
+        expect { config.mode = :by_object }.not_to raise_error
+        expect { config.show_diffs = :normative }.not_to raise_error
+        expect { config.algorithm = :semantic }.not_to raise_error
+        expect { config.theme = :dark }.not_to raise_error
+        expect { config.pretty_printer.indent_type = :tab }.not_to raise_error
+        expect { config.display_preprocessing = :pretty_print }.not_to raise_error
+        expect { config.display_format = :canonical }.not_to raise_error
+        expect { config.character_visualization = :content_only }.not_to raise_error
+      end
+    end
+  end
 end

--- a/spec/canon/diff_formatter/diff_detail_formatter_spec.rb
+++ b/spec/canon/diff_formatter/diff_detail_formatter_spec.rb
@@ -487,7 +487,7 @@ RSpec.describe "DiffDetailFormatter helpers" do
       n
     end
 
-    it "with expand_difference: false shows only the tag name" do
+    it "with expand_difference: false shows compact XML with content" do
       node1 = element_node_for_expand("biblio-tag", "ISO 712, ")
       node2 = element_node_for_expand("span", "ISO 712, ")
       diff = Canon::Diff::DiffNode.new(node1: node1, node2: node2,
@@ -499,11 +499,11 @@ RSpec.describe "DiffDetailFormatter helpers" do
         use_color: false,
         expand_difference: false,
       )
-      expect(report).to include("<biblio-tag>")
-      expect(report).not_to include("<biblio-tag>ISO 712, </biblio-tag>")
+      expect(report).to include("<biblio-tag>ISO 712, </biblio-tag>")
+      expect(report).to include("<span>ISO 712, </span>")
     end
 
-    it "with expand_difference: true shows full serialized node content" do
+    it "with expand_difference: true shows compact XML with content" do
       node1 = element_node_for_expand("biblio-tag", "ISO 712, ")
       node2 = element_node_for_expand("span", "ISO 712, ")
       diff = Canon::Diff::DiffNode.new(node1: node1, node2: node2,
@@ -517,8 +517,7 @@ RSpec.describe "DiffDetailFormatter helpers" do
       )
       expect(report).to include("<biblio-tag>ISO 712, </biblio-tag>")
       expect(report).to include("<span>ISO 712, </span>")
-      # Changes line still shows just the tag names
-      expect(report).to include("Element differs: biblio-tag")
+      expect(report).to include("Element structure changed:")
     end
 
     it "with expand_difference: true via DiffFormatter.new the report uses full content" do
@@ -540,6 +539,123 @@ RSpec.describe "DiffDetailFormatter helpers" do
                                                   "<root/>")
       expect(output).to include("<biblio-tag>ISO 712, </biblio-tag>")
       expect(output).to include("<span>ISO 712, </span>")
+    end
+  end
+
+  # ── Element structure diff display ──────────────────────────────────────────
+
+  describe "element_structure diff display" do
+    require "canon/diff_formatter/diff_detail_formatter"
+    require "canon/diff_formatter/diff_detail_formatter/dimension_formatter"
+
+    def element_node(name, text_value = nil, attrs: {})
+      n = Canon::Xml::Nodes::ElementNode.new(name: name)
+      attrs.each do |k, v|
+        attr_node = Canon::Xml::Nodes::AttributeNode.new(name: k, value: v)
+        n.add_attribute(attr_node)
+      end
+      n.add_child(Canon::Xml::Nodes::TextNode.new(value: text_value)) if text_value
+      n
+    end
+
+    describe "both elements present, different names" do
+      it "shows compact XML for both sides" do
+        node1 = element_node("biblio-tag", "ISO 712, ")
+        node2 = element_node("span", "ISO 712, ")
+        diff = Canon::Diff::DiffNode.new(
+          node1: node1, node2: node2,
+          dimension: :element_structure, reason: "element name differs",
+        )
+
+        detail1, detail2, changes = Canon::DiffFormatter::DiffDetailFormatterHelpers::DimensionFormatter.format_element_structure_details(diff, false)
+
+        expect(detail1).to eq("<biblio-tag>ISO 712, </biblio-tag>")
+        expect(detail2).to eq("<span>ISO 712, </span>")
+        expect(changes).to include("Element structure changed:")
+        expect(changes).to include("<biblio-tag>ISO 712, </biblio-tag>")
+        expect(changes).to include("<span>ISO 712, </span>")
+      end
+
+      it "shows attributes in compact XML" do
+        node1 = element_node("div", "text", attrs: { "class" => "old" })
+        node2 = element_node("span", "text", attrs: { "class" => "new" })
+        diff = Canon::Diff::DiffNode.new(
+          node1: node1, node2: node2,
+          dimension: :element_structure, reason: "element name differs",
+        )
+
+        detail1, detail2, _changes = Canon::DiffFormatter::DiffDetailFormatterHelpers::DimensionFormatter.format_element_structure_details(diff, false)
+
+        expect(detail1).to include("class=\"old\"")
+        expect(detail2).to include("class=\"new\"")
+      end
+    end
+
+    describe "both elements present, same name (children differ)" do
+      it "shows children-differ message" do
+        node1 = element_node("div", "old text")
+        node2 = element_node("div", "new text")
+        diff = Canon::Diff::DiffNode.new(
+          node1: node1, node2: node2,
+          dimension: :element_structure, reason: "element structure mismatch",
+        )
+
+        detail1, detail2, changes = Canon::DiffFormatter::DiffDetailFormatterHelpers::DimensionFormatter.format_element_structure_details(diff, false)
+
+        expect(detail1).to eq("<div>old text</div>")
+        expect(detail2).to eq("<div>new text</div>")
+        expect(changes).to eq("Element <div> structure changed (children differ)")
+      end
+    end
+
+    describe "element deleted (node2 is nil)" do
+      it "shows removed element with (not present) for the new side" do
+        node1 = element_node("removed", "content")
+        diff = Canon::Diff::DiffNode.new(
+          node1: node1, node2: nil,
+          dimension: :element_structure, reason: "element removed",
+        )
+
+        detail1, detail2, changes = Canon::DiffFormatter::DiffDetailFormatterHelpers::DimensionFormatter.format_element_structure_details(diff, false)
+
+        expect(detail1).to eq("<removed>content</removed>")
+        expect(detail2).to eq("(not present)")
+        expect(changes).to include("Element removed:")
+        expect(changes).to include("<removed>content</removed>")
+      end
+    end
+
+    describe "element inserted (node1 is nil)" do
+      it "shows added element with (not present) for the old side" do
+        node2 = element_node("added", "content")
+        diff = Canon::Diff::DiffNode.new(
+          node1: nil, node2: node2,
+          dimension: :element_structure, reason: "element inserted",
+        )
+
+        detail1, detail2, changes = Canon::DiffFormatter::DiffDetailFormatterHelpers::DimensionFormatter.format_element_structure_details(diff, false)
+
+        expect(detail1).to eq("(not present)")
+        expect(detail2).to eq("<added>content</added>")
+        expect(changes).to include("Element added:")
+        expect(changes).to include("<added>content</added>")
+      end
+    end
+
+    describe "element with no text content" do
+      it "serializes as self-closing tag" do
+        node1 = element_node("empty")
+        node2 = element_node("br")
+        diff = Canon::Diff::DiffNode.new(
+          node1: node1, node2: node2,
+          dimension: :element_structure, reason: "element name differs",
+        )
+
+        detail1, detail2, _changes = Canon::DiffFormatter::DiffDetailFormatterHelpers::DimensionFormatter.format_element_structure_details(diff, false)
+
+        expect(detail1).to eq("<empty/>")
+        expect(detail2).to eq("<br/>")
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Two independent improvements:

**1. Config enum validation** (commit 1)
- Adds `VALID_ENUM_VALUES` and `validate_config_value!` to `DiffConfig`
- All enum-like setters (`mode=`, `show_diffs=`, `algorithm=`, `display_format=`, `display_preprocessing=`, `character_visualization=`, `theme=`, `indent_type=`) now raise `ArgumentError` with clear messages on invalid values
- Previously, invalid values were silently accepted and caused wrong output downstream

**2. Element structure diff display** (commit 2)
- `format_element_structure_details` now always shows compact XML (attributes + text content), not just tag names
- Handles nil nodes (element inserted/removed) with descriptive labels
- Same-name elements with structural differences get a distinct "children differ" message
- Removed unused `expand_difference` parameter

## Test plan
- [x] All 2051 tests pass
- [x] New tests for all 9 enum validations + `apply_profile_data` validation
- [x] New tests for all element_structure edge cases (different names, same name, element added, element removed, self-closing, attributes)