### PR TITLE
fix: strip formatting whitespace in HTMLAdapter Canon path

### DIFF
--- a/lib/canon/tree_diff/adapters/html_adapter.rb
+++ b/lib/canon/tree_diff/adapters/html_adapter.rb
@@ -200,6 +200,19 @@ module Canon
           whitespace_sensitive_tags.include?(element.name.downcase)
         end
 
+        # Check if a text value is formatting-only whitespace
+        #
+        # Formatting whitespace contains newlines (indentation between
+        # block elements) and is safe to strip. Pure spaces/tabs without
+        # newlines may be semantically significant between inline elements
+        # and are preserved.
+        #
+        # @param text [String] Text value to check
+        # @return [Boolean] True if formatting-only whitespace
+        def formatting_whitespace?(text)
+          text.match?(/\A[\s\p{Zs}]*\z/) && text.include?("\n")
+        end
+
         # Build Nokogiri element from TreeNode
         #
         # @param tree_node [Core::TreeNode] Tree node
@@ -270,10 +283,23 @@ module Canon
             source_node: element_node, # Preserve reference to Canon node
           )
 
-          # Process children recursively
+          # Process children recursively, filtering formatting whitespace
+          # in non-whitespace-sensitive elements.
+          #
+          # HTML distinguishes between formatting whitespace (newlines +
+          # indentation between block elements) and inline whitespace
+          # (spaces between inline elements like <span>). Only formatting
+          # whitespace is stripped — inline spaces are semantically
+          # significant because they render as visible gaps.
           element_node.children.each do |child|
             child_tree = to_tree(child)
-            tree_node.add_child(child_tree) if child_tree
+            next if child_tree.nil?
+
+            if child_tree.label == "text" && !whitespace_sensitive?(element_node)
+              next if formatting_whitespace?(child_tree.value)
+            end
+
+            tree_node.add_child(child_tree)
           end
 
           tree_node

--- a/spec/canon/tree_diff/whitespace_sensitive_spec.rb
+++ b/spec/canon/tree_diff/whitespace_sensitive_spec.rb
@@ -116,5 +116,43 @@ RSpec.describe "Whitespace-sensitive elements" do
       expect(html1).to be_html_equivalent_to(html2,
                                              match: { text_content: :normalize })
     end
+
+    it "treats block-layout whitespace differences as equivalent under semantic diff" do
+      html1 = <<~HTML
+        <div>
+          <p>Hello</p>
+          <p>World</p>
+        </div>
+      HTML
+
+      html2 = "<div><p>Hello</p><p>World</p></div>"
+
+      result = Canon::Comparison.equivalent?(
+        html1,
+        html2,
+        format: :html,
+        diff_algorithm: :semantic_tree,
+        verbose: true,
+      )
+
+      expect(result.equivalent?).to be true
+    end
+
+    it "detects text content whitespace differences under semantic diff" do
+      html1 = "<div><span>Hello World</span></div>"
+      html2 = "<div><span>HelloWorld</span></div>"
+
+      result = Canon::Comparison.equivalent?(
+        html1,
+        html2,
+        format: :html,
+        diff_algorithm: :semantic_tree,
+        verbose: true,
+      )
+
+      expect(result.equivalent?).to be false
+      normative_diffs = result.differences.select(&:normative?)
+      expect(normative_diffs).not_to be_empty
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Fix HTMLAdapter to strip formatting whitespace (newlines + indentation) at the parent element level in `to_tree_from_canon_element`, aligning with XMLAdapter behavior
- Preserve spaces between inline elements and all whitespace in whitespace-sensitive containers (pre, code, textarea, script, style)
- Add `formatting_whitespace?` private method as a clean HTML-specific heuristic

## Test plan
- [x] Existing whitespace-sensitive specs (pre, code, textarea) all pass
- [x] New spec: block-layout whitespace differences are equivalent under semantic diff
- [x] New spec: text content whitespace differences are still detected as normative
- [x] Full suite: 2053 examples, 0 failures

Closes #98