### PR TITLE
feat: add Canon::Comparison.summarize API

### DIFF
--- a/lib/canon/comparison.rb
+++ b/lib/canon/comparison.rb
@@ -144,6 +144,35 @@ module Canon
         dom_diff(obj1, obj2, opts)
       end
 
+      # Summarize the first difference between two documents.
+      #
+      # Returns a human-readable string describing the first difference
+      # when documents differ, or "Equivalent" when they match.
+      # This is a lightweight alternative to +equivalent?+ with +verbose: true+.
+      #
+      # @param obj1 [Object] First object to compare
+      # @param obj2 [Object] Second object to compare
+      # @param opts [Hash] Comparison options (same as +equivalent?+)
+      # @return [String] Summary string
+      #
+      # @example
+      #   Canon::Comparison.summarize("<p>Hello</p>", "<p>World</p>")
+      #   # => "Not equivalent: text content differs at /p[1] (Hello vs World)"
+      #
+      #   Canon::Comparison.summarize("<p>Hello</p>", "<p>Hello</p>")
+      #   # => "Equivalent"
+      def summarize(obj1, obj2, opts = {})
+        result = equivalent?(obj1, obj2, opts.merge(verbose: true))
+
+        if result.is_a?(ComparisonResult)
+          result.summary
+        elsif result == true
+          "Equivalent"
+        else
+          "Not equivalent"
+        end
+      end
+
       # Define a custom comparison profile with DSL syntax
       #
       # @param name [Symbol] Profile name

--- a/lib/canon/comparison/comparison_result.rb
+++ b/lib/canon/comparison/comparison_result.rb
@@ -84,6 +84,30 @@ html_version: nil, match_options: nil, algorithm: :dom, original_strings: nil)
         @match_options&.[](:tree_diff_operations) || []
       end
 
+      # Generate a human-readable summary of the first difference.
+      #
+      # When documents are equivalent, returns "Equivalent".
+      # When they differ, returns a single-line string with the first normative
+      # (or first informative) difference location and reason.
+      #
+      # @return [String] Summary string
+      def summary
+        return "Equivalent" if equivalent?
+
+        diff = normative_differences.first || informative_differences.first ||
+               @differences.first
+
+        return "Not equivalent" unless diff
+
+        if diff.is_a?(Canon::Diff::DiffNode)
+          summarize_diff_node(diff)
+        elsif diff.is_a?(Hash)
+          summarize_legacy_hash(diff)
+        else
+          "Not equivalent"
+        end
+      end
+
       # Generate formatted diff output
       #
       # @param use_color [Boolean] Whether to use ANSI color codes
@@ -115,6 +139,59 @@ show_diffs: :all, diff_mode: :separate, legacy_terminal: false)
           doc2: @preprocessed_strings[1],
           html_version: @html_version,
         )
+      end
+
+      private
+
+      # Format a single DiffNode into a summary string.
+      #
+      # @param diff [DiffNode] The difference to summarize
+      # @return [String] Human-readable summary
+      def summarize_diff_node(diff)
+        parts = ["Not equivalent:"]
+
+        if diff.path
+          parts << "#{diff.reason} at #{diff.path}"
+        else
+          parts << diff.reason.to_s
+        end
+
+        if diff.serialized_before && diff.serialized_after
+          before_preview = truncate_preview(diff.serialized_before)
+          after_preview = truncate_preview(diff.serialized_after)
+          parts << "(#{before_preview} vs #{after_preview})"
+        end
+
+        parts.join(" ")
+      end
+
+      # Format a legacy Hash difference into a summary string.
+      #
+      # @param diff [Hash] Legacy difference hash with :path, :value1, :value2
+      # @return [String] Human-readable summary
+      def summarize_legacy_hash(diff)
+        parts = ["Not equivalent:"]
+        parts << "#{diff[:diff_code_description]} at #{diff[:path]}" if diff[:path]
+
+        if diff[:value1] && diff[:value2]
+          parts << "(#{truncate_preview(diff[:value1].to_s)} vs #{truncate_preview(diff[:value2].to_s)})"
+        end
+
+        parts.size > 1 ? parts.join(" ") : "Not equivalent: values differ"
+      end
+
+      # Truncate a string for preview display.
+      #
+      # @param text [String] Text to truncate
+      # @param max_len [Integer] Maximum length
+      # @return [String] Truncated text with ellipsis if needed
+      def truncate_preview(text, max_len = 40)
+        stripped = text.strip.gsub(/\s+/, " ")
+        if stripped.length > max_len
+          "#{stripped[0...(max_len - 3)]}..."
+        else
+          stripped
+        end
       end
     end
   end

--- a/spec/canon/comparison/summarize_spec.rb
+++ b/spec/canon/comparison/summarize_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Canon::Comparison.summarize" do
+  describe "equivalent documents" do
+    it "returns 'Equivalent' for identical XML" do
+      xml = "<root><item>Hello</item></root>"
+      expect(Canon::Comparison.summarize(xml, xml)).to eq("Equivalent")
+    end
+
+    it "returns 'Equivalent' for semantically equivalent XML" do
+      compact = "<root><a>text</a></root>"
+      expanded = "<root>\n  <a>text</a>\n</root>"
+      expect(Canon::Comparison.summarize(compact, expanded)).to eq("Equivalent")
+    end
+
+    it "returns 'Equivalent' for identical JSON" do
+      json1 = '{"a": 1, "b": 2}'
+      json2 = '{"a": 1, "b": 2}'
+      expect(Canon::Comparison.summarize(json1, json2)).to eq("Equivalent")
+    end
+  end
+
+  describe "differing documents" do
+    it "includes 'Not equivalent' when text content differs" do
+      xml1 = "<root><item>Hello</item></root>"
+      xml2 = "<root><item>World</item></root>"
+      summary = Canon::Comparison.summarize(xml1, xml2)
+      expect(summary).to start_with("Not equivalent:")
+    end
+
+    it "includes the diff reason" do
+      xml1 = "<root><item>Hello</item></root>"
+      xml2 = "<root><item>World</item></root>"
+      summary = Canon::Comparison.summarize(xml1, xml2)
+      # XML comparator produces reasons like 'Text: "Hello" vs "World"'
+      expect(summary).to include("Text")
+    end
+
+    it "includes the path when available" do
+      xml1 = "<p>Hello</p>"
+      xml2 = "<p>World</p>"
+      summary = Canon::Comparison.summarize(xml1, xml2)
+      expect(summary).to include("/p")
+    end
+
+    it "shows value preview for text differences" do
+      xml1 = "<root><item>Hello</item></root>"
+      xml2 = "<root><item>World</item></root>"
+      summary = Canon::Comparison.summarize(xml1, xml2)
+      expect(summary).to include("Hello")
+      expect(summary).to include("World")
+      expect(summary).to include("vs")
+    end
+
+    it "reports missing nodes" do
+      xml1 = "<root><a/><b/></root>"
+      xml2 = "<root><a/></root>"
+      summary = Canon::Comparison.summarize(xml1, xml2)
+      expect(summary).to start_with("Not equivalent:")
+    end
+
+    it "reports attribute differences" do
+      xml1 = '<root attr="old"/>'
+      xml2 = '<root attr="new"/>'
+      summary = Canon::Comparison.summarize(xml1, xml2)
+      expect(summary).to start_with("Not equivalent:")
+    end
+
+    it "works with JSON differences" do
+      json1 = '{"key": "value1"}'
+      json2 = '{"key": "value2"}'
+      summary = Canon::Comparison.summarize(json1, json2)
+      expect(summary).to start_with("Not equivalent")
+      expect(summary).to include("value1")
+      expect(summary).to include("value2")
+    end
+  end
+
+  describe "regression guard" do
+    it "equivalent? still returns plain boolean" do
+      xml = "<root><item>Hello</item></root>"
+      result = Canon::Comparison.equivalent?(xml, xml)
+      expect(result).to eq(true)
+    end
+
+    it "equivalent? returns false for differing docs" do
+      xml1 = "<root><item>Hello</item></root>"
+      xml2 = "<root><item>World</item></root>"
+      result = Canon::Comparison.equivalent?(xml1, xml2)
+      expect(result).to eq(false)
+    end
+
+    it "accepts same opts as equivalent?" do
+      xml1 = "<root><a>text</a></root>"
+      xml2 = "<root><a>text</a></root>"
+      summary = Canon::Comparison.summarize(xml1, xml2, profile: :strict)
+      expect(summary).to eq("Equivalent")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `Canon::Comparison.summarize(a, b)` returning a human-readable string describing the first difference
- Adds `ComparisonResult#summary` instance method
- Returns "Equivalent" when documents match
- Handles both DiffNode (XML/HTML) and legacy Hash (JSON/YAML) difference formats
- `equivalent?` unchanged — still returns plain boolean

## Test plan
- [x] 13 new specs in `spec/canon/comparison/summarize_spec.rb`
- [x] Full suite passes: 2073 examples, 0 failures
- [x] Regression guard: `equivalent?` still returns plain boolean