### PR TITLE
feat: make SAX parser default for non-C14N comparisons

### DIFF
--- a/lib/canon/comparison/xml_comparator/node_parser.rb
+++ b/lib/canon/comparison/xml_comparator/node_parser.rb
@@ -14,15 +14,18 @@ module Canon
         # @param node [String, Object] Node to parse
         # @param preprocessing [Symbol] Preprocessing mode (:none, :normalize, :c14n, :format)
         # @param preserve_whitespace [Boolean] Whether to preserve whitespace-only text nodes
+        # @param parser [Symbol] Parser backend (:sax or :dom, default from config)
         # @return [Canon::Xml::Node] Parsed node
-        def self.parse(node, preprocessing = :none, preserve_whitespace: false)
+        def self.parse(node, preprocessing = :none, preserve_whitespace: false,
+                       parser: nil)
           # If already a Canon::Xml::Node, return as-is
           return node if node.is_a?(Canon::Xml::Node)
 
           # If it's a Nokogiri or Moxml node, convert to DataModel
           unless node.is_a?(String)
             return convert_from_node(node,
-                                     preserve_whitespace: preserve_whitespace)
+                                     preserve_whitespace: preserve_whitespace,
+                                     parser: parser)
           end
 
           # Normalize encoding before preprocessing (UTF-16 strings can't use strip, etc.)
@@ -31,9 +34,17 @@ module Canon
           # Apply preprocessing to XML string before parsing
           xml_string = apply_preprocessing(node, preprocessing).strip
 
-          # Use Canon::Xml::DataModel for parsing to get Canon::Xml::Node instances
-          Canon::Xml::DataModel.from_xml(xml_string,
+          # Select parser backend
+          resolved_parser = parser || resolve_parser_config
+
+          if resolved_parser == :sax
+            require_relative "../../xml/sax_builder"
+            Canon::Xml::SaxBuilder.parse(xml_string,
                                          preserve_whitespace: preserve_whitespace)
+          else
+            Canon::Xml::DataModel.from_xml(xml_string,
+                                           preserve_whitespace: preserve_whitespace)
+          end
         end
 
         # Apply preprocessing transformation to XML string
@@ -62,9 +73,10 @@ module Canon
         #
         # @param node [Object] Nokogiri or Moxml node
         # @param preserve_whitespace [Boolean] Whether to preserve whitespace-only text nodes
+        # @param parser [Symbol, nil] Parser backend override
         # @return [Canon::Xml::Node] Converted node
-        def self.convert_from_node(node, preserve_whitespace: false)
-          # Convert to XML string then parse through DataModel
+        def self.convert_from_node(node, preserve_whitespace: false, parser: nil)
+          # Convert to XML string then parse through selected backend
           xml_str = if node.respond_to?(:to_xml)
                       node.to_xml
                     elsif node.respond_to?(:to_s)
@@ -73,8 +85,26 @@ module Canon
                       raise Canon::Error,
                             "Unable to convert node to string: #{node.class}"
                     end
-          Canon::Xml::DataModel.from_xml(xml_str,
+
+          resolved_parser = parser || resolve_parser_config
+
+          if resolved_parser == :sax
+            require_relative "../../xml/sax_builder"
+            Canon::Xml::SaxBuilder.parse(xml_str,
                                          preserve_whitespace: preserve_whitespace)
+          else
+            Canon::Xml::DataModel.from_xml(xml_str,
+                                           preserve_whitespace: preserve_whitespace)
+          end
+        end
+
+        # Resolve parser config from global config
+        #
+        # @return [Symbol] :sax or :dom
+        def self.resolve_parser_config
+          Canon::Config.instance.xml.diff.parser
+        rescue StandardError
+          :sax
         end
       end
     end

--- a/lib/canon/config.rb
+++ b/lib/canon/config.rb
@@ -299,6 +299,7 @@ module Canon
         mode: %i[by_line by_object pretty_diff],
         show_diffs: %i[all normative informative],
         algorithm: %i[dom semantic],
+        parser: %i[sax dom],
         display_preprocessing: %i[none pretty_print normalize_pretty_print c14n],
         display_format: %i[raw canonical],
         pretty_printer_indent_type: %i[space tab],
@@ -678,6 +679,16 @@ module Canon
         @resolver.set_programmatic(:algorithm, value)
       end
 
+      # XML parser backend (:sax or :dom, default :sax)
+      def parser
+        @resolver.resolve(:parser)
+      end
+
+      def parser=(value)
+        self.class.validate_config_value!(:parser, value)
+        @resolver.set_programmatic(:parser, value)
+      end
+
       # Theme name (:light, :dark, :retro, :claude)
       def theme
         @resolver.resolve(:theme)
@@ -725,6 +736,7 @@ module Canon
           show_diffs: show_diffs,
           verbose_diff: verbose_diff,
           diff_algorithm: algorithm,
+          parser: parser,
           show_raw_inputs: show_raw_inputs,
           show_raw_expected: show_raw_expected,
           show_raw_received: show_raw_received,
@@ -765,6 +777,7 @@ module Canon
           show_diffs: :all,
           verbose_diff: false,
           algorithm: :dom,
+          parser: :sax,
           show_raw_inputs: false,
           show_raw_expected: false,
           show_raw_received: false,

--- a/lib/canon/config/env_schema.rb
+++ b/lib/canon/config/env_schema.rb
@@ -14,6 +14,7 @@ module Canon
         show_diffs: :symbol,
         verbose_diff: :boolean,
         algorithm: :symbol,
+        parser: :symbol,
         show_raw_inputs: :boolean,
         show_raw_expected: :boolean,
         show_raw_received: :boolean,
@@ -66,7 +67,7 @@ module Canon
 
         def all_diff_attributes
           %i[mode use_color context_lines grouping_lines show_diffs
-             verbose_diff algorithm show_raw_inputs show_raw_expected show_raw_received
+             verbose_diff algorithm parser show_raw_inputs show_raw_expected show_raw_received
              show_preprocessed_inputs show_preprocessed_expected show_preprocessed_received
              show_prettyprint_inputs show_prettyprint_expected show_prettyprint_received
              show_line_numbered_inputs character_visualization

--- a/spec/canon/xml/sax_default_parser_spec.rb
+++ b/spec/canon/xml/sax_default_parser_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "SAX parser as default" do
+  after do
+    Canon::Config.instance.xml.diff.reset!
+  end
+
+  describe "config option" do
+    it "defaults to :sax" do
+      expect(Canon::Config.instance.xml.diff.parser).to eq(:sax)
+    end
+
+    it "can be set to :dom" do
+      Canon::Config.instance.xml.diff.parser = :dom
+      expect(Canon::Config.instance.xml.diff.parser).to eq(:dom)
+    end
+
+    it "validates the value" do
+      expect {
+        Canon::Config.instance.xml.diff.parser = :invalid
+      }.to raise_error(ArgumentError, /Invalid value/)
+    end
+  end
+
+  describe "comparison results match" do
+    let(:xml1) { "<root><item>Hello</item></root>" }
+    let(:xml2) { "<root><item>World</item></root>" }
+
+    it "SAX and DOM produce equivalent? results" do
+      Canon::Config.instance.xml.diff.parser = :sax
+      sax_result = Canon::Comparison.equivalent?(xml1, xml2)
+
+      Canon::Config.instance.xml.diff.parser = :dom
+      dom_result = Canon::Comparison.equivalent?(xml1, xml2)
+
+      expect(sax_result).to eq(dom_result)
+    end
+
+    it "SAX produces correct equivalence for identical documents" do
+      expect(Canon::Comparison.equivalent?(xml1, xml1)).to be true
+    end
+
+    it "SAX produces correct non-equivalence for differing documents" do
+      expect(Canon::Comparison.equivalent?(xml1, xml2)).to be false
+    end
+
+    it "SAX produces same verbose differences as DOM" do
+      Canon::Config.instance.xml.diff.parser = :sax
+      sax_result = Canon::Comparison.equivalent?(xml1, xml2, verbose: true)
+
+      Canon::Config.instance.xml.diff.parser = :dom
+      dom_result = Canon::Comparison.equivalent?(xml1, xml2, verbose: true)
+
+      expect(sax_result.equivalent?).to eq(dom_result.equivalent?)
+      expect(sax_result.differences.size).to eq(dom_result.differences.size)
+    end
+  end
+
+  describe "C14N uses DOM regardless of parser config" do
+    it "canonicalizes correctly even with SAX as default" do
+      Canon::Config.instance.xml.diff.parser = :sax
+      xml = '<root attr="value"><child>text</child></root>'
+      result = Canon::Xml::C14n.canonicalize(xml, with_comments: false)
+      expect(result).to include("<root")
+      expect(result).to include("<child>text</child>")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `parser` config option (`:sax` / `:dom`) to `DiffConfig`, defaulting to `:sax`
- `NodeParser.parse` conditionally uses `SaxBuilder` (~6x faster) when `parser == :sax`
- C14N path continues using DOM regardless of config
- Configurable via `Canon.config.xml.diff.parser = :dom` or env var `CANON_XML_DIFF_PARSER=dom`

## Test plan
- [x] 8 new specs: config default, config validation, SAX/DOM equivalence, C14N independence
- [x] Full suite passes: 2081 examples, 0 failures (SAX produces identical results to DOM)
- [x] `reset!` in `after` block ensures no config leakage between specs