### PR TITLE
feat: implement C14N subset selection via XPath

### DIFF
--- a/lib/canon/xml/c14n.rb
+++ b/lib/canon/xml/c14n.rb
@@ -2,6 +2,7 @@
 
 require_relative "data_model"
 require_relative "processor"
+require_relative "xpath_engine"
 
 module Canon
   module Xml
@@ -21,15 +22,68 @@ module Canon
         processor.process(root_node)
       end
 
-      # Canonicalize a document subset (for future implementation)
+      # Canonicalize a document subset selected by XPath expression.
+      #
+      # Implements W3C C14N 1.1 subset canonicalization:
+      # 1. Evaluates XPath against the document tree
+      # 2. Marks matched nodes as the node-set
+      # 3. Renders canonical form for only the selected nodes,
+      #    with namespace and attribute inheritance from excluded ancestors
+      #
       # @param xml [String] XML document as string
       # @param xpath [String] XPath expression for subset selection
       # @param with_comments [Boolean] Include comments in canonical form
       # @return [String] Canonical form in UTF-8
-      def self.canonicalize_subset(xml, _xpath, with_comments: false)
-        # TODO: Implement XPath-based subset selection
-        # For now, just canonicalize the whole document
-        canonicalize(xml, with_comments: with_comments)
+      def self.canonicalize_subset(xml, xpath, with_comments: false)
+        root_node = DataModel.from_xml(xml)
+
+        # Mark all nodes as NOT in the node-set initially
+        mark_all_nodes(root_node, false)
+
+        # Evaluate XPath and mark matched nodes
+        matched = XPathEngine.evaluate(root_node, xpath)
+
+        # If XPath matches root or is empty, fall back to full canonicalization
+        if matched.empty?
+          mark_all_nodes(root_node, true)
+        else
+          # Mark matched nodes and their ancestors/descendants
+          mark_subset(root_node, matched)
+        end
+
+        # Process to canonical form
+        processor = Processor.new(with_comments: with_comments)
+        processor.process(root_node)
+      end
+
+      class << self
+        private
+
+        # Recursively set in_node_set on all nodes
+        def mark_all_nodes(node, value)
+          node.in_node_set = value
+          node.children.each { |child| mark_all_nodes(child, value) }
+        end
+
+        # Mark matched nodes and all required supporting nodes.
+        #
+        # Per W3C C14N 1.1, only nodes in the node-set are rendered.
+        # Ancestors not in the node-set become "omitted ancestors" —
+        # the Processor handles namespace/attribute inheritance from them.
+        def mark_subset(root_node, matched)
+          # Mark matched nodes and their descendants
+          matched.each do |node|
+            mark_node_and_descendants(node)
+          end
+
+          # Root node is always in the set so processing starts
+          root_node.in_node_set = true
+        end
+
+        def mark_node_and_descendants(node)
+          node.in_node_set = true
+          node.children.each { |child| mark_node_and_descendants(child) }
+        end
       end
     end
   end

--- a/lib/canon/xml/node.rb
+++ b/lib/canon/xml/node.rb
@@ -17,7 +17,7 @@ module Canon
       end
 
       def in_node_set?
-        @in_node_set ||= true
+        instance_variable_defined?(:@in_node_set) ? @in_node_set : true
       end
 
       def in_node_set=(value)

--- a/lib/canon/xml/xpath_engine.rb
+++ b/lib/canon/xml/xpath_engine.rb
@@ -1,0 +1,236 @@
+# frozen_string_literal: true
+
+module Canon
+  module Xml
+    # XPath evaluation engine for C14N subset selection.
+    #
+    # Supports a focused subset of XPath 1.0 sufficient for W3C C14N
+    # subset canonicalization:
+    #
+    # - Absolute paths: /root/child, /root/child[1]
+    # - Descendant-or-self: //element, //ns:element
+    # - Predicates: [1] (position), [@attr], [@attr='value']
+    # - Wildcards: *
+    # - Union: expr1 | expr2
+    #
+    # Not supported (not needed for C14N subset):
+    # - Axes other than child and descendant-or-self
+    # - Functions (last(), position(), etc.)
+    # - Variables
+    #
+    class XPathEngine
+      # Evaluate an XPath expression against a data model tree.
+      #
+      # @param root [Nodes::RootNode] Root of the data model tree
+      # @param xpath [String] XPath expression
+      # @return [Array<Node>] Matched nodes in document order
+      def self.evaluate(root, xpath)
+        new(root).evaluate(xpath)
+      end
+
+      def initialize(root)
+        @root = root
+      end
+
+      # Evaluate an XPath expression and return matched nodes.
+      #
+      # @param xpath [String] XPath expression
+      # @return [Array<Node>] Matched nodes in document order
+      def evaluate(xpath)
+        # Handle union operator (|)
+        if xpath.include?("|")
+          xpath.split("|").flat_map { |expr| evaluate(expr.strip) }.uniq
+        else
+          evaluate_path(xpath.strip)
+        end
+      end
+
+      private
+
+      def evaluate_path(xpath)
+        if xpath.start_with?("//")
+          # Descendant-or-self: anywhere in the tree
+          evaluate_descendant(xpath[2..])
+        elsif xpath.start_with?("/")
+          # Absolute path
+          evaluate_absolute(xpath[1..])
+        else
+          # Relative path — treat as descendant
+          evaluate_descendant(xpath)
+        end
+      end
+
+      def evaluate_absolute(path)
+        return [] if path.empty?
+
+        steps = parse_steps(path)
+        return [] if steps.empty?
+
+        # Start from root's children
+        current_nodes = @root.children
+        apply_steps(current_nodes, steps)
+      end
+
+      def evaluate_descendant(path)
+        steps = parse_steps(path)
+        return [] if steps.empty?
+
+        # Collect all descendant element nodes
+        all_elements = []
+        collect_elements(@root, all_elements)
+
+        # For each element, try to match the full path starting there
+        result = []
+        all_elements.each do |element|
+          first_step = steps.first
+          next unless step_matches?(element, first_step)
+
+          if steps.length == 1
+            result << element
+          else
+            remaining = steps[1..]
+            matched = apply_steps(element.children, remaining)
+            result.concat(matched)
+          end
+        end
+
+        result.uniq
+      end
+
+      def collect_elements(node, result)
+        node.children.each do |child|
+          next unless child.is_a?(Nodes::ElementNode)
+
+          result << child
+          collect_elements(child, result)
+        end
+      end
+
+      def apply_steps(nodes, steps)
+        return nodes if steps.empty?
+
+        step = steps.first
+        remaining = steps[1..]
+
+        matched = nodes.select { |n| step_matches?(n, step) }
+
+        if remaining.empty?
+          matched
+        else
+          matched.flat_map do |node|
+            apply_steps(node.children, remaining)
+          end
+        end
+      end
+
+      def step_matches?(node, step)
+        return false unless node.is_a?(Nodes::ElementNode)
+
+        name_matches?(node, step[:name]) &&
+          predicates_match?(node, step[:predicates])
+      end
+
+      def name_matches?(node, name)
+        return true if name == "*"
+
+        # Handle prefixed names (ns:element)
+        if name.include?(":")
+          prefix, local = name.split(":", 2)
+          node.prefix == prefix && node.name == local
+        else
+          node.name == name
+        end
+      end
+
+      def predicates_match?(node, predicates)
+        return true if predicates.empty?
+
+        predicates.all? { |pred| predicate_matches?(node, pred) }
+      end
+
+      def predicate_matches?(node, pred)
+        case pred[:type]
+        when :position
+          # [1] — position among siblings with same name
+          position_predicate?(node, pred[:value])
+        when :attribute_exists
+          # [@attr]
+          node.attribute_nodes.any? { |a| a.local_name == pred[:name] }
+        when :attribute_value
+          # [@attr='value']
+          node.attribute_nodes.any? do |a|
+            a.local_name == pred[:name] && a.value == pred[:value]
+          end
+        else
+          false
+        end
+      end
+
+      def position_predicate?(node, position)
+        siblings = node.parent&.children&.select { |n| n.is_a?(Nodes::ElementNode) && n.name == node.name } || []
+        idx = siblings.index(node)
+        idx && (idx + 1) == position
+      end
+
+      # Parse a path string into an array of steps.
+      #
+      # @param path [String] XPath path (without leading /)
+      # @return [Array<Hash>] Array of { name:, predicates: }
+      def parse_steps(path)
+        steps = []
+        scanner = StringScanner.new(path)
+
+        until scanner.eos?
+          scanner.skip(/\s+/)
+          break if scanner.eos?
+
+          # Skip /
+          scanner.scan(%r{/})
+
+          name = scan_name(scanner)
+          break if name.nil?
+
+          predicates = scan_predicates(scanner)
+
+          steps << { name: name, predicates: predicates }
+        end
+
+        steps
+      end
+
+      def scan_name(scanner)
+        scanner.scan(%r{[a-zA-Z_][\w:.-]*|\*})
+      end
+
+      def scan_predicates(scanner)
+        predicates = []
+        while scanner.scan(/\[/)
+          scanner.skip(/\s*/)
+          pred = scan_predicate(scanner)
+          scanner.skip(/\s*/)
+          scanner.scan(/\]/)
+          predicates << pred if pred
+        end
+        predicates
+      end
+
+      def scan_predicate(scanner)
+        if scanner.scan(/(\d+)/)
+          { type: :position, value: scanner[1].to_i }
+        elsif scanner.scan(/@/)
+          name = scanner.scan(/[a-zA-Z_][\w.-]*/)
+
+          if scanner.scan(/=/)
+            # Remove surrounding quotes if present
+            scanner.scan(/['"]/)
+            value = scanner.scan(/[^'"\]]+/)
+            scanner.scan(/['"]/)
+            { type: :attribute_value, name: name, value: value }
+          else
+            { type: :attribute_exists, name: name }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/canon/xml/c14n_subset_spec.rb
+++ b/spec/canon/xml/c14n_subset_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Canon::Xml::C14n do
+  describe ".canonicalize_subset" do
+    describe "simple element selection" do
+      it "selects a single element by name" do
+        xml = "<root><a>1</a><b>2</b></root>"
+        result = described_class.canonicalize_subset(xml, "//b")
+        expect(result).to eq("<b>2</b>")
+      end
+
+      it "selects by absolute path" do
+        xml = "<root><a>1</a><b>2</b></root>"
+        result = described_class.canonicalize_subset(xml, "/root/b")
+        expect(result).to eq("<b>2</b>")
+      end
+
+      it "selects multiple elements" do
+        xml = "<root><item>a</item><item>b</item></root>"
+        result = described_class.canonicalize_subset(xml, "//item")
+        expect(result).to eq("<item>a</item><item>b</item>")
+      end
+
+      it "selects by wildcard" do
+        xml = "<root><a>1</a><b>2</b></root>"
+        result = described_class.canonicalize_subset(xml, "/*")
+        expect(result).to include("<a>1</a>")
+        expect(result).to include("<b>2</b>")
+      end
+    end
+
+    describe "nested elements" do
+      it "selects deeply nested element" do
+        xml = "<root><a><b><c>text</c></b></a></root>"
+        result = described_class.canonicalize_subset(xml, "//c")
+        expect(result).to eq("<c>text</c>")
+      end
+
+      it "inherits namespaces from excluded ancestors" do
+        xml = '<root xmlns:ns="http://example.com"><ns:child>text</ns:child></root>'
+        result = described_class.canonicalize_subset(xml, "//ns:child")
+        expect(result).to include("ns:child")
+        expect(result).to include("xmlns:ns")
+        expect(result).to include("text")
+      end
+    end
+
+    describe "predicate support" do
+      it "selects by position [1]" do
+        xml = "<root><item>first</item><item>second</item><item>third</item></root>"
+        result = described_class.canonicalize_subset(xml, "//item[1]")
+        expect(result).to eq("<item>first</item>")
+      end
+
+      it "selects by attribute existence [@attr]" do
+        xml = '<root><item selected="yes">a</item><item>b</item></root>'
+        result = described_class.canonicalize_subset(xml, "//item[@selected]")
+        expect(result).to eq('<item selected="yes">a</item>')
+      end
+
+      it "selects by attribute value [@attr=\'value\']" do
+        xml = '<root><item type="a">1</item><item type="b">2</item></root>'
+        result = described_class.canonicalize_subset(xml, "//item[@type='a']")
+        expect(result).to eq('<item type="a">1</item>')
+      end
+    end
+
+    describe "union expressions" do
+      it "selects nodes matching either expression" do
+        xml = "<root><a>1</a><b>2</b><c>3</c></root>"
+        result = described_class.canonicalize_subset(xml, "//a | //c")
+        expect(result).to include("<a>1</a>")
+        expect(result).to include("<c>3</c>")
+        expect(result).not_to include("<b>2</b>")
+      end
+    end
+
+    describe "fallback behavior" do
+      it "falls back to full canonicalization when XPath matches root" do
+        xml = "<root><a>1</a></root>"
+        full = described_class.canonicalize(xml)
+        result = described_class.canonicalize_subset(xml, "/root")
+        expect(result).to eq(full)
+      end
+
+      it "falls back to full canonicalization when XPath matches nothing" do
+        xml = "<root><a>1</a></root>"
+        full = described_class.canonicalize(xml)
+        result = described_class.canonicalize_subset(xml, "//nonexistent")
+        expect(result).to eq(full)
+      end
+    end
+
+    describe "with_comments option" do
+      it "excludes comments by default" do
+        xml = "<root><!-- comment --><a>text</a></root>"
+        result = described_class.canonicalize_subset(xml, "//a")
+        expect(result).not_to include("comment")
+      end
+
+      it "includes comments when with_comments: true" do
+        xml = "<root><a><!-- inner -->text</a></root>"
+        result = described_class.canonicalize_subset(xml, "//a", with_comments: true)
+        expect(result).to include("<!-- inner -->")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Implements `C14n.canonicalize_subset(xml, xpath)` with actual XPath evaluation
- New `XPathEngine` supports: `//element`, `/root/child`, `[1]`, `[@attr]`, `[@attr='value']`, `*`, union (`|`)
- Correctly handles namespace/attribute inheritance from omitted ancestors per W3C C14N 1.1
- Fixes critical bug in `Node#in_node_set?` where `||=` treated `false` as unset

Closes #1

## Test plan
- [x] 14 new specs in `spec/canon/xml/c14n_subset_spec.rb`
- [x] Full suite passes: 2095 examples, 0 failures
- [x] Existing C14N specs unaffected (backward compatible)