### PR TITLE
fix: rubocop offenses in inline whitespace/entity handling code

### DIFF
--- a/lib/canon/comparison.rb
+++ b/lib/canon/comparison.rb
@@ -753,11 +753,7 @@ module Canon
         # Serialize back, preserving the resolved characters.
         # to_html re-encodes characters, so use inner_html which
         # keeps the character form.
-        result = doc.inner_html
-
-        # If the serialization re-encoded characters as entities,
-        # that's fine — the XML parser understands numeric refs like &#160;
-        result
+        doc.inner_html
       end
 
       # Detect the format of an object (delegates to FormatDetector)

--- a/lib/canon/comparison/whitespace_sensitivity.rb
+++ b/lib/canon/comparison/whitespace_sensitivity.rb
@@ -236,6 +236,7 @@ module Canon
         # @return [Boolean] true if whitespace is between inline siblings
         def inline_whitespace_significant?(text_node)
           return false unless text_node.respond_to?(:parent)
+
           parent = text_node.parent
           return false unless parent
           return false unless parent.respond_to?(:children)
@@ -402,8 +403,6 @@ module Canon
             parent
           elsif parent.respond_to?(:node_type) && parent.node_type == :element
             parent
-          else
-            nil
           end
         end
 

--- a/lib/canon/diff/diff_classifier.rb
+++ b/lib/canon/diff/diff_classifier.rb
@@ -170,8 +170,6 @@ module Canon
                  node.content
                elsif node.respond_to?(:value)
                  node.value
-               else
-                 nil
                end
         if text && Canon::Comparison::WhitespaceSensitivity.contains_nbsp?(text)
           return true

--- a/lib/canon/html/data_model.rb
+++ b/lib/canon/html/data_model.rb
@@ -215,19 +215,18 @@ module Canon
         # and when whitespace is between inline element siblings (semantically significant)
         content = nokogiri_text.content
 
-        if content.strip.empty? && nokogiri_text.parent.is_a?(Nokogiri::XML::Element)
+        if content.strip.empty? && nokogiri_text.parent.is_a?(Nokogiri::XML::Element) &&
+            !content.include?("\u00A0")
           # NBSP (U+00A0) is never insignificant whitespace
-          unless content.include?("\u00A0")
-            # Check if parent is whitespace-sensitive
-            parent_name = nokogiri_text.parent.name.downcase
-            whitespace_sensitive_tags = %w[pre code textarea script style]
+          # Check if parent is whitespace-sensitive
+          parent_name = nokogiri_text.parent.name.downcase
+          whitespace_sensitive_tags = %w[pre code textarea script style]
 
-            # Check if whitespace is between inline siblings
-            require_relative "../comparison/whitespace_sensitivity"
-            unless whitespace_sensitive_tags.include?(parent_name) ||
-                     Canon::Comparison::WhitespaceSensitivity.inline_whitespace_significant?(nokogiri_text)
-              return nil
-            end
+          # Check if whitespace is between inline siblings
+          require_relative "../comparison/whitespace_sensitivity"
+          unless whitespace_sensitive_tags.include?(parent_name) ||
+              Canon::Comparison::WhitespaceSensitivity.inline_whitespace_significant?(nokogiri_text)
+            return nil
           end
         end
 


### PR DESCRIPTION
## Summary
Fixes rubocop offenses introduced in PR #107:
- Redundant assignment before returning (`comparison.rb`)
- Missing empty line after guard clause (`whitespace_sensitivity.rb`)
- Redundant else-clause (`whitespace_sensitivity.rb`, `diff_classifier.rb`)
- Merge nested conditions / indentation (`data_model.rb`)

## Test plan
- [x] All 2112 tests pass
- [x] Rubocop clean on all changed files