### PR TITLE
improved reporting of dsemantic  diference, if the changed nodes are …

### DIFF
--- a/docs/advanced/semantic-diff-report.adoc
+++ b/docs/advanced/semantic-diff-report.adoc
@@ -148,6 +148,37 @@ Location:   /html/body/div/table/tbody/tr/td/pre/text
 
 The warning appears for text inside whitespace-preserving elements where Canon automatically switches to strict mode.
 
+==== Parent-context fallback for ambiguous text diffs
+
+For a `text_content` difference, Canon normally renders the two sides as JSON-quoted strings.
+When both sides would collapse to the same (or visually indistinguishable) short string -- both empty (`""`), both whitespace-only, or both equal on the text-node extraction even though the surrounding DOM differs -- that rendering conveys nothing.
+
+In this case Canon instead serializes each side's *parent element* compactly and visualizes whitespace (`·` for space, `→` for tab, `¬` for newline, `<NBSP>` for non-breaking space) so the structural contrast is visible.
+
+.Example: Ambiguous empty-vs-whitespace text diff
+[example]
+====
+[source]
+----
+🔍 DIFFERENCE #1/1 [NORMATIVE]
+──────────────────────────────────────────────────────────────────────
+Dimension: text_content
+Location:  /#document[0]/fmt-title[0]/span[0]/span/text()[0]
+Reason:  Text: "¬······:¬······"
+          vs.: ":"
+
+⊖ Expected (File 1):
+   <span·class="fmt-caption-delim">¬······:¬······<tab/>¬···</span>
+⊕ Actual (File 2):
+   <span·class="fmt-caption-delim">:<tab/></span>
+
+✨ Changes:
+   Content differs: <span·class="fmt-caption-delim">¬······:¬······<tab/>¬···</span> → <span·class="fmt-caption-delim">:<tab/></span>
+----
+====
+
+This fallback is implemented in `Canon::DiffFormatter::DiffDetailFormatterHelpers::DimensionFormatter.format_text_content_details` and only triggers when `TextUtils.ambiguous_text_pair?` returns `true` _and_ at least one side has a parent element to render.
+
 === Structural Whitespace
 
 Shows whitespace-only differences (usually informative).

--- a/lib/canon/diff_formatter/diff_detail_formatter/dimension_formatter.rb
+++ b/lib/canon/diff_formatter/diff_detail_formatter/dimension_formatter.rb
@@ -385,6 +385,20 @@ expand_difference: false)
             detail2 = ColorHelper.colorize(
               TextUtils.visualize_whitespace(text2), :green, use_color
             )
+          elsif TextUtils.ambiguous_text_pair?(text1, text2) &&
+              (NodeUtils.parent_of(node1) || NodeUtils.parent_of(node2))
+            # Both sides render to empty/whitespace-only strings, which are
+            # indistinguishable after JSON quoting.  Fall back to each side's
+            # parent element serialized compactly, with whitespace visualized
+            # so the reader can see the structural contrast.
+            ctx1 = NodeUtils.serialize_node_compact(NodeUtils.parent_of(node1))
+            ctx2 = NodeUtils.serialize_node_compact(NodeUtils.parent_of(node2))
+            detail1 = ColorHelper.colorize(
+              TextUtils.visualize_whitespace(ctx1), :red, use_color
+            )
+            detail2 = ColorHelper.colorize(
+              TextUtils.visualize_whitespace(ctx2), :green, use_color
+            )
           elsif compact && (node1.is_a?(Canon::Xml::Nodes::ElementNode) ||
                            node2.is_a?(Canon::Xml::Nodes::ElementNode))
             # In compact mode with element nodes, display as raw XML without

--- a/lib/canon/diff_formatter/diff_detail_formatter/node_utils.rb
+++ b/lib/canon/diff_formatter/diff_detail_formatter/node_utils.rb
@@ -318,6 +318,23 @@ module Canon
           end
         end
 
+        # Return the parent of a node, or nil, regardless of the node API.
+        #
+        # Canon::Xml nodes expose +parent+; some Nokogiri-shaped nodes expose
+        # +parent_node+.  This helper abstracts over both.
+        #
+        # @param node [Object] Node to query
+        # @return [Object, nil] Parent node or nil
+        def self.parent_of(node)
+          return nil unless node
+
+          if node.respond_to?(:parent)
+            node.parent
+          elsif node.respond_to?(:parent_node)
+            node.parent_node
+          end
+        end
+
         # Check if node is inside a preserve-whitespace element
         #
         # @param node [Object] Node to check

--- a/lib/canon/diff_formatter/diff_detail_formatter/text_utils.rb
+++ b/lib/canon/diff_formatter/diff_detail_formatter/text_utils.rb
@@ -83,6 +83,33 @@ module Canon
           end.join
         end
 
+        # Whether two text values would be visually indistinguishable when
+        # rendered through the standard JSON-quoting path.
+        #
+        # Covers three cases that collapse to near-identical short strings
+        # like +""+ / +" "+ / +":"+ / +":"+:
+        #   * both sides empty
+        #   * both sides whitespace-only (possibly with different whitespace
+        #     that JSON.generate preserves verbatim but a reader cannot tell
+        #     apart from plain spaces)
+        #   * both sides equal (the comparator reported a diff based on
+        #     something the text-only extraction does not surface — e.g. a
+        #     sibling text node that exists on one side and not the other)
+        #
+        # Callers should fall back to rendering parent-element context
+        # instead.
+        #
+        # @param text1 [String, nil]
+        # @param text2 [String, nil]
+        # @return [Boolean]
+        def self.ambiguous_text_pair?(text1, text2)
+          blank_or_whitespace = ->(t) { t.nil? || t.empty? || t.match?(/\A\s+\z/) }
+          return true if blank_or_whitespace.call(text1) &&
+            blank_or_whitespace.call(text2)
+
+          text1 == text2
+        end
+
         # Check if text contains non-ASCII or non-printable characters
         #
         # @param text [String] Text to check

--- a/spec/canon/comparison/xml_comparator_spec.rb
+++ b/spec/canon/comparison/xml_comparator_spec.rb
@@ -308,5 +308,42 @@ RSpec.describe Canon::Comparison::XmlComparator do
       end
     end
     # rubocop:enable Layout/LineLength
+
+    context "ambiguous whitespace-only text diffs (issue #112)" do
+      it "renders parent-element context with visualized whitespace " \
+         "when both sides of a text_content diff are empty/whitespace-only" do
+        input = <<~INPUT
+          <fmt-title depth="1" id="_">
+             <span class="fmt-caption-delim">
+                :
+                <tab/>
+             </span>
+             <semx element="title" source="_">General</semx>
+          </fmt-title>
+        INPUT
+        output = <<~OUTPUT
+          <fmt-title depth="1" id="_"><span class="fmt-caption-delim">:<tab/></span><semx element="title" source="_">General</semx></fmt-title>
+        OUTPUT
+
+        result = described_class.equivalent?(input, output, verbose: true)
+        expect(result.equivalent?).to be false
+
+        report = Canon::DiffFormatter::DiffDetailFormatter.format_report(
+          result.differences, use_color: false
+        )
+
+        # Expected/Actual must not both collapse to bare "" quotes — the
+        # parent-context fallback should kick in.
+        empty_pair = /Expected \(File 1\): ""\n.*Actual \(File 2\)\s*: ""/m
+        expect(report).not_to match(empty_pair)
+
+        # Parent-context rendering for both sides, with whitespace
+        # visualized on the whitespace-rich side so the reader can see
+        # the structural difference.
+        expect(report).to include("fmt-caption-delim")
+        expect(report).to include("<tab/>")
+        expect(report).to match(/[¬→·]/)
+      end
+    end
   end
 end


### PR DESCRIPTION
…whitespace/blank/identical text, by reference to parent node: #112