### PR TITLE
fix: respect YAML whitespace_type override and unbreak pretty-printed fixtures (#110)

### DIFF
--- a/lib/canon/comparison.rb
+++ b/lib/canon/comparison.rb
@@ -693,8 +693,14 @@ module Canon
         # but defined in config
         if Canon::Config.instance.respond_to?(comparison_format)
           format_config = Canon::Config.instance.public_send(comparison_format)
-          if opts[:match_profile].nil? && format_config.match.profile
-            opts[:match_profile] = format_config.match.profile
+          if opts[:global_profile].nil? && format_config.match.profile
+            # Config-sourced profile has *global* priority (applied before
+            # global_options), so that YAML profile_options like
+            # whitespace_type: :normalize can override the built-in profile
+            # (e.g. :spec_friendly)'s whitespace_type: :strict.  Writing to
+            # :match_profile here gave the config profile per-call priority,
+            # which incorrectly overrode the YAML's own overrides.
+            opts[:global_profile] = format_config.match.profile
           end
           # Pass YAML profile's extra match options (e.g., preserve_whitespace_elements)
           # that are stored in MatchConfig's resolver but not exposed via the

--- a/lib/canon/comparison/xml_comparator.rb
+++ b/lib/canon/comparison/xml_comparator.rb
@@ -104,11 +104,16 @@ module Canon
           # Create child_opts with resolved options
           child_opts = opts.merge(child_opts)
 
-          # Determine if we should preserve whitespace during parsing
-          # Preserve when structural_whitespace is :strict OR whitespace_type is :strict
-          # (so the comparator can detect different Unicode whitespace types)
-          preserve_whitespace = match_opts_hash[:structural_whitespace] == :strict ||
-            (match_opts_hash[:whitespace_type] || :strict) == :strict
+          # Determine if we should preserve whitespace during parsing.
+          # Only structural_whitespace: :strict forces whitespace-only text
+          # nodes to survive parsing.  whitespace_type is about distinguishing
+          # Unicode whitespace *types* in surviving text-node content, and
+          # does NOT require indent text nodes to be kept — libxml's NOBLANKS
+          # only strips pure-ASCII whitespace-only nodes, so NBSP-only nodes
+          # survive regardless.  Coupling whitespace_type: :strict to
+          # parsing-time preservation made pretty-printed fixtures produce
+          # spurious element-position diffs (issue #112).
+          preserve_whitespace = match_opts_hash[:structural_whitespace] == :strict
 
           # Parse nodes if they are strings, applying preprocessing if needed
           node1 = parse_node(n1, match_opts_hash[:preprocessing],

--- a/lib/canon/xml/sax_builder.rb
+++ b/lib/canon/xml/sax_builder.rb
@@ -182,11 +182,16 @@ strip_doctype: false)
 
         # Skip whitespace-only text nodes unless:
         # 1. preserve_whitespace is true, OR
-        # 2. The content contains CR (from &#xD; entities) which must be preserved for C14N
+        # 2. The content contains CR (from &#xD; entities) which must be preserved for C14N, OR
+        # 3. The content contains non-ASCII whitespace (NBSP U+00A0, ideographic
+        #    space U+3000, etc.) — those are semantically meaningful content,
+        #    not pretty-print indentation, and must survive parsing so the
+        #    comparator can detect Unicode whitespace-type differences.
         #
-        # Use \p{Space} to match all Unicode whitespace (including NBSP U+00A0)
-        # so that NBSP-only text nodes are stripped consistently with regular spaces.
-        if !@preserve_whitespace && decoded_string.gsub(/\p{Space}/,
+        # Strip only when the node is pure ASCII whitespace (space, tab, CR, LF).
+        # This lets pretty-printed fixtures work (indent nodes stripped) while
+        # preserving NBSP-only text nodes.
+        if !@preserve_whitespace && decoded_string.gsub(/[ \t\r\n]/,
                                                         "").empty? && parent.node_type == :element && !decoded_string.include?("\r")
           # Only skip if parent is an element (not root)
           return

--- a/spec/canon/pretty_printer/html_roundtrip_spec.rb
+++ b/spec/canon/pretty_printer/html_roundtrip_spec.rb
@@ -228,8 +228,8 @@ RSpec.describe "Pretty-print roundtrip (issue #116)" do
       OUTPUT
     end
 
-    # putting on hold
-    xit "raw output is html4-equivalent to canon_013_pretty_print (hardcoded old style)" do
+    it "raw output is html4-equivalent to canon_013_pretty_print (hardcoded old style)",
+       skip: "on hold, there's a lot of fixing of Canon whitespace behaviour in progress, and I may or may not end up requiring it to be addressed" do
       expect(raw_output).to be_html4_equivalent_to(canon_013_pretty_print)
     end
 

--- a/spec/canon/pretty_printer/html_roundtrip_spec.rb
+++ b/spec/canon/pretty_printer/html_roundtrip_spec.rb
@@ -1,0 +1,254 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "nokogiri"
+require "canon/pretty_printer/html"
+
+# Regression test for https://github.com/lutaml/canon/issues/116
+#
+# Pins the roundtrip property: under the :metanorma match profile, raw HTML
+# emitted by a Metanorma document processor must be html4-equivalent to its
+# own Canon-pretty-printed form. The pretty-printed form is what Canon emits
+# when CANON_HTML_DIFF_SHOW_PRETTYPRINT_RECEIVED=1 is set; users copy-paste
+# that block back as a fixture, so it must compare equal to the raw input
+# that produced it.
+#
+# canon_023_pretty_print is generated dynamically via the same call path
+# DiffFormatter#prettyprint_for_display uses (lib/canon/diff_formatter.rb:929-948).
+# canon_013_pretty_print is the older expanded form (one child per line) and
+# is kept as a separate hardcoded heredoc to pin its behavior independently.
+RSpec.describe "Pretty-print roundtrip (issue #116)" do
+  around do |ex|
+    saved = Canon::Config.instance.profile
+    Canon::Config.instance.profile = :metanorma
+    ex.run
+  ensure
+    Canon::Config.instance.profile = saved
+  end
+
+  def canon_pretty_print(raw)
+    Canon::PrettyPrinter::Html
+      .new(indent: 2, indent_type: "space")
+      .format(raw)
+  end
+
+  describe "simple body (a_spec.rb fixture)" do
+    let(:raw_output) do
+      <<~OUTPUT
+        <body lang="EN-US" link="blue" vlink="#954F72">
+          <div class="WordSection1">
+            <p>&#xA0;</p>
+          </div>
+          <p class="section-break">
+            <br clear="all" class="section"/>
+          </p>
+          <div class="WordSection2">
+            <div class="WordSectionContents">
+              <h1 class="IEEEStdsLevel1frontmatter">Contents</h1>
+            </div>
+            <p>&#xA0;</p>
+          </div>
+          <p class="section-break">
+            <br clear="all" class="section"/>
+          </p>
+          <p class="section-break">
+            <br clear="all" style="page-break-before:auto;mso-break-type:section-break"/>
+          </p>
+          <div class="WordSectionMain">
+            <div id="_"><h1>1.<span style="mso-tab-count:1">&#xA0; </span>Terms and Definitions</h1>
+            <p>For the purposes of this document, the following terms and definitions apply.</p><p class="TermNum" id="paddy1"/>
+
+        <p><b>paddy</b>, &lt;rice&gt;, &lt;in agriculture, dated&gt;<span class="fmt-termsource-delim">(</span><span class="std_publisher">ISO&#xA0;</span><span class="std_docNumber">7301</span>:<span class="std_year">2011</span>,  3.1, modified &#x2014; The term "cargo rice" is shown as deprecated, and Note 1 to entry is not included here<span class="fmt-termsource-delim">)</span>: rice retaining its husk after threshing <span class="fmt-termsource-delim">(</span>adapted from t1, adapted; Termbase IEV, term ID xyz, adapted &#x2014; with adjustments<span class="fmt-termsource-delim">)</span></p>
+        <div id="_" class="example" style="page-break-after: avoid;page-break-inside: avoid;"><p class="example-title"><i>Example 1</i><i>:</i></p>
+          <p id="_">Foreign seeds, husks, bran, sand, dust.</p>
+          <div class="ul_wrap"><ul>
+          <li id="_">A</li>
+          </ul></div>
+        </div>
+        <div id="_" class="example"><p class="example-title"><i>Example 2</i><i>:</i></p>
+          <div class="ul_wrap"><ul>
+          <li id="_">A</li>
+          </ul></div>
+        </div>
+
+
+
+
+
+        <p><b>paddy</b>: rice retaining its husk after threshing <i>Syn:</i> <b>paddy rice</b>, &lt;in agriculture&gt;; <b>rough rice</b>. <span class="fmt-termsource-delim">[</span><span class="std_publisher">ISO&#xA0;</span><span class="std_docNumber">7301</span>:<span class="std_year">2011</span>,  3(1)<span class="fmt-termsource-delim">]</span></p>
+        <div id="_" class="example"><p class="example-title"><i>Example</i><i>:</i></p>
+          <div class="ul_wrap"><ul>
+          <li id="_">A</li>
+          </ul></div>
+        </div>
+        <div id="_" class="Note" style="page-break-after: avoid;page-break-inside: avoid;"><p><span class="note_label">NOTE 1&#x2014;</span>The starch of waxy rice consists almost entirely of amylopectin. The kernels have a tendency to stick together after cooking.</p></div>
+        <div id="_" class="Note"><p><span class="note_label">NOTE 2&#x2014;</span>The starch of waxy rice consists almost entirely of amylopectin. The kernels have a tendency to stick together after cooking.</p></div>
+
+        <p><b>paddy rice</b>, &lt;in agriculture&gt;:  <i>See:</i> <b>paddy</b>.</p><p class="TermNum" id="_"/>
+
+        <p><b>rough rice</b>:  <i>See:</i> <b>paddy</b>.</p>
+
+
+
+
+        </div>
+          </div>
+        </body>
+      OUTPUT
+    end
+
+    let(:canon_013_pretty_print) do
+      <<~OUTPUT
+        <body lang="EN-US" link="blue" vlink="#954F72">
+           <div class="WordSection1">
+              <p> </p>
+           </div>
+           <p class="section-break">
+              <br clear="all" class="section"/>
+           </p>
+           <div class="WordSection2">
+              <div class="WordSectionContents">
+                 <h1 class="IEEEStdsLevel1frontmatter">Contents</h1>
+              </div>
+              <p> </p>
+           </div>
+           <p class="section-break">
+              <br clear="all" class="section"/>
+           </p>
+           <div class="WordSectionMiddleTitle"/>
+           <p class="section-break">
+              <br clear="all" style="page-break-before:auto;mso-break-type:section-break"/>
+           </p>
+           <div class="WordSectionMain">
+              <div id="_">
+                 <h1>
+                    1.
+                    <span style="mso-tab-count:1">  </span>
+                    Terms and Definitions
+                 </h1>
+                 <p>For the purposes of this document, the following terms and definitions apply.</p>
+                 <p class="TermNum" id="paddy1"/>
+                 <p>
+                    <b>paddy</b>
+                    , &lt;rice&gt;, &lt;in agriculture, dated&gt;
+                    <span class="fmt-termsource-delim">(</span>
+                    <span class="std_publisher">ISO&#xA0;</span>
+                    <span class="std_docNumber">7301</span>
+                    :
+                    <span class="std_year">2011</span>
+                    ,  3.1, modified — The term "cargo rice" is shown as deprecated, and Note 1 to entry is not included here
+                    <span class="fmt-termsource-delim">)</span>
+                    : rice retaining its husk after threshing
+                    <span class="fmt-termsource-delim">(</span>
+                    adapted from t1, adapted; Termbase IEV, term ID xyz, adapted — with adjustments
+                    <span class="fmt-termsource-delim">)</span>
+                 </p>
+                 <div id="_" class="example" style="page-break-after: avoid;page-break-inside: avoid;">
+                    <p class="example-title">
+                       <i>Example 1</i>
+                       <i>:</i>
+                    </p>
+                    <p id="_">Foreign seeds, husks, bran, sand, dust.</p>
+                    <div class="ul_wrap">
+                       <ul>
+                          <li id="_">A</li>
+                       </ul>
+                    </div>
+                 </div>
+                 <div id="_" class="example">
+                    <p class="example-title">
+                       <i>Example 2</i>
+                       <i>:</i>
+                    </p>
+                    <div class="ul_wrap">
+                       <ul>
+                          <li id="_">A</li>
+                       </ul>
+                    </div>
+                 </div>
+                 <p class="TermNum" id="paddy"/>
+                 <p>
+                    <b>paddy</b>
+                    : rice retaining its husk after threshing
+                    <i>Syn:</i>
+                    <b>paddy rice</b>
+                    , &lt;in agriculture&gt;;
+                    <b>rough rice</b>
+                    .
+                    <span class="fmt-termsource-delim">[</span>
+                    <span class="std_publisher">ISO&#xA0;</span>
+                    <span class="std_docNumber">7301</span>
+                    :
+                    <span class="std_year">2011</span>
+                    ,  3(1)
+                    <span class="fmt-termsource-delim">]</span>
+                 </p>
+                 <div id="_" class="example">
+                    <p class="example-title">
+                       <i>Example</i>
+                       <i>:</i>
+                    </p>
+                    <div class="ul_wrap">
+                       <ul>
+                          <li id="_">A</li>
+                       </ul>
+                    </div>
+                 </div>
+                 <div id="_" class="Note" style="page-break-after: avoid;page-break-inside: avoid;">
+                    <p>
+                       <span class="note_label">NOTE 1—</span>
+                       The starch of waxy rice consists almost entirely of amylopectin. The kernels have a tendency to stick together after cooking.
+                    </p>
+                 </div>
+                 <div id="_" class="Note">
+                    <p>
+                       <span class="note_label">NOTE 2—</span>
+                       The starch of waxy rice consists almost entirely of amylopectin. The kernels have a tendency to stick together after cooking.
+                    </p>
+                 </div>
+                 <p class="TermNum" id="_"/>
+                 <p>
+                    <b>paddy rice</b>
+                    , &lt;in agriculture&gt;:
+                    <i>See:</i>
+                    <b>paddy</b>
+                    .
+                 </p>
+                 <p class="TermNum" id="_"/>
+                 <p>
+                    <b>rough rice</b>
+                    :
+                    <i>See:</i>
+                    <b>paddy</b>
+                    .
+                 </p>
+              </div>
+           </div>
+        </body>
+      OUTPUT
+    end
+
+    # putting on hold
+    xit "raw output is html4-equivalent to canon_013_pretty_print (hardcoded old style)" do
+      expect(raw_output).to be_html4_equivalent_to(canon_013_pretty_print)
+    end
+
+    it "raw output is html4-equivalent to canon_023_pretty_print (dynamic)" do
+      expect(raw_output).to be_html4_equivalent_to(canon_pretty_print(raw_output))
+    end
+
+    # Body extracted from metanorma-ieee IsoDoc::Ieee::WordConvert output via
+    # Nokogiri::HTML5(word_html).at("//body").to_html — the parser-correct
+    # path. The status-quo metanorma-ieee call uses Nokogiri::XML/to_xml,
+    # which is being fixed out of band; this fixture pins the HTML5/to_html
+    # form so the canon-side regression is testable without the metanorma
+    # toolchain.
+
+    it "Nokogiri extracted output is html4-equivalent to canon_023_pretty_print (dynamic)" do
+      expect(Nokogiri::HTML5(raw_output).at_xpath("//body").to_html)
+        .to be_html4_equivalent_to(canon_pretty_print(raw_output))
+      expect(Nokogiri::HTML5(raw_output).at_xpath("//body").to_xml)
+        .to be_html4_equivalent_to(canon_pretty_print(raw_output))
+    end
+  end
+end


### PR DESCRIPTION
Closes / addresses #110 follow-up. This is a follow-up to #111 (commit 860b2f4).

## Summary

Commit 860b2f4 landed `whitespace_type: :strict` as the default for every XML/HTML profile and updated `metanorma.yml` to `whitespace_type: :normalize` "for backward compatibility". In practice, metanorma-iso regressed hard: `spec/isodoc/xref_section_spec.rb:550` (previously passing) now reports **25 bogus normative differences** against an unchanged fixture.

Investigation found **two independent bugs** that combined to cause the regression. This PR ships each as a separate commit so a maintainer who prefers the smaller change can take just Commit 1.

---

## Bug A — YAML `whitespace_type: :normalize` is silently ignored (Commit 1)

`lib/canon/comparison.rb:696-698` was writing the config's `match.profile` (`:spec_friendly`) into the **per-call** `match_profile` slot. In `BaseResolver#resolve`, per-call profile is applied *after* `global_options`, so `:spec_friendly`'s `whitespace_type: :strict` overwrote the YAML's `whitespace_type: :normalize` that `comparison.rb:702-708` had just injected via `global_options`. Net effect: the metanorma maintainer's intended opt-out never applied.

**Fix:** route the config-sourced profile through `:global_profile` (applied before `global_options`), so YAML `profile_options` can override the built-in profile's strict defaults, as intended.

With Commit 1 alone, the metanorma-iso regression is resolved because `metanorma.yml`'s `whitespace_type: :normalize` now actually wins.

---

## Bug B — `whitespace_type: :strict` forces parse-time preservation (Commit 2)

Even when a user keeps the default `whitespace_type: :strict` and doesn't override it, `lib/canon/comparison/xml_comparator.rb:98-99` forces `preserve_whitespace: true` during parsing. That keeps *all* whitespace-only text nodes — including pretty-print indentation — in the DOM, which shifts sibling positions during child-pairing and produces spurious `element_structure`/`text_content` diffs for pretty-printed fixtures.

The coupling exists because `SaxBuilder#characters` (`lib/canon/xml/sax_builder.rb:189`) used `\p{Space}` to decide which whitespace-only text nodes to strip. `\p{Space}` matches U+00A0 (NBSP) and other non-ASCII whitespace, so NBSP-only text nodes were stripped at parse time alongside plain-space nodes. The only way to make NBSP detection work in #110 was to preserve everything.

**Fix:**

1. Narrow the SAX filter to ASCII whitespace only (`[ \t\r\n]`) so NBSP-only and ideographic-space-only nodes survive parsing on their own merit.
2. Drop the `whitespace_type == :strict` branch from `xml_comparator.rb`'s preservation decision — `structural_whitespace` is the only signal that should force parse-time preservation.

Commit 2 is an independent design correction: it makes the default `whitespace_type: :strict` safe for pretty-printed fixtures, so users who haven't set a profile also don't get burned.

---

## Why ship both

They're orthogonal. Commit 1 fixes the immediate regression for anyone using the metanorma profile. Commit 2 closes the same trap for users on the default profile. A maintainer who prefers the smaller intervention can take Commit 1 and revert Commit 2; the regression fix still lands.

---

## Verification

Tested with `metanorma-iso` via `path: "../canon"` in `Gemfile.devel`:

| Variant | Canon suite | `metanorma-iso xref_section_spec` |
|---|---|---|
| Commit 1 only | 2116 examples, 0 failures | 3 examples, 0 failures |
| Commits 1+2 | 2116 examples, 0 failures | 3 examples, 0 failures |

The canon #110 regression spec (`space vs NBSP between inline elements (issue #110)`) passes under both variants:
- Commit 1 alone: `metanorma.yml`'s `whitespace_type: :normalize` now wins, but the test itself uses `match_profile: :spec_friendly` with default `:strict` — NBSP detection still works via the `xml_comparator.rb` parse-time coupling that is untouched in Commit 1.
- Commits 1+2: NBSP-only nodes still survive SAX stripping via the `[ \t\r\n]` narrowing, so detection works without the parse-time coupling.

## Test plan

- [ ] CI runs full canon suite on this branch
- [ ] Downstream `metanorma-iso` regression confirmed fixed (reporter: please re-point your `Gemfile.devel` to this branch and re-run `spec/isodoc/xref_section_spec.rb:550`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
