### PR TITLE
fix: strip leading <?xml ?> from HTML input before fragment parsing (#122)

### DIFF
--- a/docs/understanding/formats/html.adoc
+++ b/docs/understanding/formats/html.adoc
@@ -210,6 +210,16 @@ Automatically detects HTML5, HTML4, or XHTML based on DOCTYPE and structure.
 
 Internally, both matchers parse input via `Nokogiri::HTML5.fragment`. (Earlier releases routed `:html` and `:html4` through `Nokogiri::XML.fragment`, which silently applied XML whitespace rules — meaning `be_html4_equivalent_to` could reject inputs that `be_html5_equivalent_to` correctly accepted.) See https://github.com/lutaml/canon/issues/118 for the full background.
 
+[[html-input-normalization]]
+=== Input normalization
+
+Before parsing, Canon strips two kinds of document-overhead syntax that would otherwise become spurious top-level nodes in the parsed fragment and cause false comparison mismatches:
+
+* `<!DOCTYPE …>` declarations (any case, any DTD) are removed. HTML version detection runs against the original input first, so detection is unaffected.
+* A leading `<?xml … ?>` processing instruction is removed. HTML5 fragment parsing treats such a PI as a "bogus comment" — it would otherwise survive as a `Nokogiri::XML::Comment` node at the head of the fragment, breaking fragment-level child-count comparison. This commonly occurs when one side of a comparison is HTML produced from an XML pipeline (for example a Nokogiri-serialized document that retains its XML declaration). See https://github.com/lutaml/canon/issues/122.
+
+Both rules apply only to syntax at the very start of the input — mid-document `<?xml ?>` PIs are left untouched.
+
 === Whitespace handling
 
 HTML whitespace is collapsed per CSS rendering rules. Empty text nodes between elements are removed. Whitespace-only text between two adjacent inline elements (`<span>A</span> <span>B</span>`) is preserved because it renders as a visible space; whitespace at a block boundary (between an inline element and a block element, or between two block siblings) is collapsed.

--- a/lib/canon/comparison/html_comparator.rb
+++ b/lib/canon/comparison/html_comparator.rb
@@ -472,6 +472,16 @@ module Canon
             node = node.strip
           end
 
+          # Strip a leading <?xml …?> processing instruction. Nokogiri::XML
+          # fragment parsing keeps the PI as a top-level node; HTML5
+          # fragment parsing converts it to a bogus comment. Either way it
+          # breaks fragment-length comparison and is not legal HTML to
+          # begin with. See lutaml/canon#122.
+          if node.start_with?("<?xml")
+            pi_end = node.index("?>")
+            node = node[(pi_end + 2)..].lstrip if pi_end
+          end
+
           # Apply preprocessing to HTML string before parsing
           html_string = case preprocessing
                         when :normalize

--- a/lib/canon/comparison/html_parser.rb
+++ b/lib/canon/comparison/html_parser.rb
@@ -82,18 +82,35 @@ module Canon
 
         # Normalize HTML to ensure consistent parsing by HTML4.fragment
         #
-        # The key issue is that HTML4.fragment treats whitespace after </head>
-        # differently than no whitespace, causing inconsistent parsing:
-        # - "</head>\n<body>" parses to [body, ...] (body is treated as content)
-        # - "</head><body>" parses to [meta, div, ...] (wrapper tags stripped)
+        # Two normalizations are applied:
         #
-        # This method normalizes the HTML to ensure consistent parsing.
+        # 1. Strip a leading +<?xml …?>+ processing instruction. HTML5
+        #    fragment parsing treats such PIs as a "bogus comment" — they
+        #    become a Nokogiri::XML::Comment node at the head of the
+        #    fragment, which then counts as a top-level child and breaks
+        #    fragment-length comparison in HtmlComparator. The PI is not
+        #    legal HTML to begin with; mirror the DOCTYPE strip already
+        #    applied in HtmlComparator.parse_node. See lutaml/canon#122.
+        #
+        # 2. Collapse whitespace between +</head>+ and +<body>+. HTML4
+        #    fragment parsing treats +</head>\n<body>+ differently from
+        #    +</head><body>+, causing formatted and minified HTML to
+        #    parse to different fragment shapes. Normalizing makes the
+        #    two parse identically.
         #
         # @param content [String] HTML content
         # @return [String] Normalized HTML content
         def normalize_html_for_parsing(content)
-          # Remove whitespace between </head> and <body> to ensure consistent parsing
-          # This makes formatted and minified HTML parse the same way
+          # 1. Strip a leading <?xml …?> PI. Use index-based slicing
+          #    rather than a regex to avoid ReDoS, mirroring the
+          #    DOCTYPE strip in HtmlComparator.parse_node.
+          stripped = content.lstrip
+          if stripped.start_with?("<?xml")
+            pi_end = stripped.index("?>")
+            content = stripped[(pi_end + 2)..] if pi_end
+          end
+
+          # 2. Collapse whitespace between </head> and <body>.
           content.gsub(%r{</head>\s*<body>}i, "</head><body>")
         end
       end

--- a/lib/canon/diff_formatter/diff_detail_formatter/node_utils.rb
+++ b/lib/canon/diff_formatter/diff_detail_formatter/node_utils.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "nokogiri"
 require_relative "../../xml/namespace_helper"
 
 module Canon
@@ -260,12 +261,15 @@ module Canon
           end
         end
 
-        # Serialize a Canon Xml node tree as compact XML for display.
+        # Serialize a node tree as compact XML for display.
         #
         # Produces a human-readable inline XML string without namespace
         # declarations and without indentation — suitable for use in Semantic
-        # Diff Report entries.  Only handles Canon::Xml::Nodes types; for any
-        # other node (Nokogiri, etc.) falls back to +get_node_text+.
+        # Diff Report entries.  Handles both +Canon::Xml::Nodes+ types and
+        # Nokogiri XML/HTML nodes (the html DOM comparison path uses
+        # Nokogiri nodes, so element-structure diffs originating there must
+        # be rendered structurally too — see issue #120).  For any other
+        # node type, falls back to +get_node_text+.
         #
         # @param node [Object] Node to serialize
         # @return [String] Compact XML string
@@ -294,8 +298,25 @@ module Canon
           when Canon::Xml::Nodes::CommentNode
             text = node.respond_to?(:value) ? node.value.to_s : ""
             "<!--#{CGI.escapeHTML(text)}-->"
+          when Nokogiri::XML::Text, Nokogiri::XML::CDATA
+            CGI.escapeHTML(node.content.to_s)
+          when Nokogiri::XML::Comment
+            "<!--#{CGI.escapeHTML(node.content.to_s)}-->"
+          when Nokogiri::XML::Element
+            tag = node.name.to_s
+            attrs = node.attribute_nodes.map do |a|
+              " #{a.name}=\"#{CGI.escapeHTML(a.value.to_s)}\""
+            end.join
+            children_xml = node.children.map do |c|
+              serialize_node_compact(c)
+            end.join
+            if children_xml.empty?
+              "<#{tag}#{attrs}/>"
+            else
+              "<#{tag}#{attrs}>#{children_xml}</#{tag}>"
+            end
           else
-            # Nokogiri nodes or other unknown types — fall back to text extraction
+            # Unknown node types — fall back to text extraction
             get_node_text(node)
           end
         end

--- a/spec/canon/comparison/html_comparator_spec.rb
+++ b/spec/canon/comparison/html_comparator_spec.rb
@@ -406,5 +406,35 @@ RSpec.describe Canon::Comparison::HtmlComparator do
         expect(described_class.equivalent?(html1, html2)).to be true
       end
     end
+
+    context "fragment-level child-count mismatch (issue #120)" do
+      # When two HTML fragments have a different number of top-level
+      # children, the diff report must identify the orphan element by
+      # tag and attributes, not as raw concatenated text content.
+      it "reports the orphan element structurally in element_structure diffs" do
+        html1 = "<div><p>1</p></div>"
+        html2 = '<div><p>1</p></div><div class="extra"><p>2</p></div>'
+
+        result = Canon::Comparison.equivalent?(
+          html1, html2, format: :html4, verbose: true
+        )
+
+        structural = result.differences.grep(Canon::Diff::DiffNode).find do |d|
+          d.dimension == :element_structure
+        end
+        expect(structural).not_to be_nil
+
+        # Render the changes text via the same formatter the user sees.
+        require "canon/diff_formatter/diff_detail_formatter/dimension_formatter"
+        formatter =
+          Canon::DiffFormatter::DiffDetailFormatterHelpers::DimensionFormatter
+        _, _, changes = formatter.format_element_structure_details(
+          structural, false
+        )
+
+        expect(changes).to include('<div class="extra">')
+        expect(changes).to include("<p>2</p>")
+      end
+    end
   end
 end

--- a/spec/canon/comparison/html_comparator_spec.rb
+++ b/spec/canon/comparison/html_comparator_spec.rb
@@ -407,6 +407,28 @@ RSpec.describe Canon::Comparison::HtmlComparator do
       end
     end
 
+    context "leading <?xml ?> processing instruction (issue #122)" do
+      let(:without_pi) do
+        "<html><body><div class=\"title\"/><br/><div class=\"main\"/></body></html>"
+      end
+      let(:with_pi) do
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n#{without_pi}"
+      end
+
+      it "treats the PI as document overhead under :html4" do
+        expect(described_class.equivalent?(with_pi, without_pi)).to be true
+        expect(
+          Canon::Comparison.equivalent?(with_pi, without_pi, format: :html4),
+        ).to be true
+      end
+
+      it "treats the PI as document overhead under :html5" do
+        expect(
+          Canon::Comparison.equivalent?(with_pi, without_pi, format: :html5),
+        ).to be true
+      end
+    end
+
     context "fragment-level child-count mismatch (issue #120)" do
       # When two HTML fragments have a different number of top-level
       # children, the diff report must identify the orphan element by

--- a/spec/canon/comparison/html_parser_spec.rb
+++ b/spec/canon/comparison/html_parser_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "canon/comparison/html_parser"
+
+RSpec.describe Canon::Comparison::HtmlParser do
+  describe ".normalize_html_for_parsing" do
+    # Issue #122: HTML5 fragment parsing treats <?xml ?> as a bogus
+    # comment, breaking fragment-length comparisons.
+    it "strips a leading <?xml ?> processing instruction" do
+      input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><html><body><p/></body></html>"
+      expect(described_class.normalize_html_for_parsing(input))
+        .to eq("<html><body><p/></body></html>")
+    end
+
+    it "tolerates whitespace before the leading PI" do
+      input = "   \n<?xml version='1.0'?>\n<html><body/></html>"
+      expect(described_class.normalize_html_for_parsing(input))
+        .to eq("\n<html><body/></html>")
+    end
+
+    it "leaves a non-leading <?xml ?> alone" do
+      input = "<html><body><p>see <?xml hi?></p></body></html>"
+      expect(described_class.normalize_html_for_parsing(input)).to eq(input)
+    end
+
+    it "still collapses whitespace between </head> and <body>" do
+      input = "<?xml version='1.0'?><html><head></head>\n  <body></body></html>"
+      expect(described_class.normalize_html_for_parsing(input))
+        .to eq("<html><head></head><body></body></html>")
+    end
+
+    it "is a no-op for plain HTML with no PI and no head/body whitespace" do
+      input = "<div><p>hi</p></div>"
+      expect(described_class.normalize_html_for_parsing(input)).to eq(input)
+    end
+  end
+
+  describe ".parse with a leading <?xml ?> (issue #122)" do
+    it "produces the same fragment children as the same input without the PI" do
+      with_pi = "<?xml version=\"1.0\"?><html><body>" \
+                "<div class=\"a\"/><div class=\"b\"/></body></html>"
+      without_pi = "<html><body><div class=\"a\"/><div class=\"b\"/></body></html>"
+
+      a = described_class.parse(with_pi, :html5).children.map(&:class)
+      b = described_class.parse(without_pi, :html5).children.map(&:class)
+      expect(a).to eq(b)
+      expect(a).not_to include(Nokogiri::XML::Comment)
+    end
+  end
+end

--- a/spec/canon/diff_formatter/diff_detail_formatter_spec.rb
+++ b/spec/canon/diff_formatter/diff_detail_formatter_spec.rb
@@ -294,6 +294,45 @@ RSpec.describe "DiffDetailFormatter helpers" do
         end
       end
 
+      context "with a Nokogiri XML element (issue #120)" do
+        it "renders tag, attributes, and children as compact XML" do
+          frag = Nokogiri::XML.fragment(
+            '<div class="extra"><p>2</p></div>',
+          )
+          element = frag.children.first
+          expect(nu.serialize_node_compact(element)).to \
+            eq('<div class="extra"><p>2</p></div>')
+        end
+
+        it "produces a self-closing tag for empty Nokogiri elements" do
+          frag = Nokogiri::XML.fragment("<br/>")
+          expect(nu.serialize_node_compact(frag.children.first)).to eq("<br/>")
+        end
+
+        it "escapes HTML entities in attribute values" do
+          frag = Nokogiri::XML.fragment('<a href="x&amp;y">link</a>')
+          expect(nu.serialize_node_compact(frag.children.first)).to \
+            eq('<a href="x&amp;y">link</a>')
+        end
+
+        it "escapes HTML entities in text children" do
+          frag = Nokogiri::XML.fragment("<p>1 &lt; 2</p>")
+          expect(nu.serialize_node_compact(frag.children.first)).to \
+            eq("<p>1 &lt; 2</p>")
+        end
+
+        it "renders Nokogiri text nodes as escaped text" do
+          text_node = Nokogiri::XML::Text.new("<>&", Nokogiri::XML::Document.new)
+          expect(nu.serialize_node_compact(text_node)).to eq("&lt;&gt;&amp;")
+        end
+
+        it "renders Nokogiri comments as <!--…-->" do
+          frag = Nokogiri::XML.fragment("<!-- hi -->")
+          comment = frag.children.first
+          expect(nu.serialize_node_compact(comment)).to eq("<!-- hi -->")
+        end
+      end
+
       context "with nil" do
         it "returns an empty string" do
           expect(nu.serialize_node_compact(nil)).to eq("")


### PR DESCRIPTION
Closes #122.

## Base

This PR is **stacked on top of #121** (`fix/120-nokogiri-compact-serialization`). The diagnosis here was only possible after #121 made element-structure diffs render Nokogiri nodes structurally. Please review and merge #121 first; this PR will rebase onto `main` once that lands. Reviewers can compare against #121 directly via the branch diff.

## Summary

`Nokogiri::HTML5.fragment` (used by `Comparison.dom_diff` for all HTML formats since #118) parses a leading `<?xml … ?>` processing instruction as a bogus `Nokogiri::XML::Comment` node at the head of the fragment. `HtmlComparator#compare_fragment_children` filters whitespace text nodes via `XmlNodeComparison.filter_children` but keeps comments — so an HTML input with the PI ends up with one extra top-level child versus the same content without it. `record_fragment_length_mismatch` then reports the *tail* of the longer side as the orphan (a separate, smaller reporting issue worth a follow-up — noted in the linked bug). The user-visible result is a confidently wrong "Element added: \<some unrelated div>" report.

This PR strips a leading `<?xml ?>` PI in `HtmlParser.normalize_html_for_parsing`, the central choke point for HTML-format input under `dom_diff`. It also extends `HtmlComparator.parse_node`'s string-input branch with the same strip (defence in depth, for callers that bypass `dom_diff`). Both use index-based slicing rather than regex, mirroring the existing DOCTYPE strip and avoiding ReDoS.

## Before / after

```ruby
with_pi    = "<?xml version='1.0'?><html><body><div/></body></html>"
without_pi = "<html><body><div/></body></html>"

# Before
Canon::Comparison.equivalent?(with_pi, without_pi, format: :html4)
# => false  (PI parsed as bogus comment, fragment-length mismatch)

# After
Canon::Comparison.equivalent?(with_pi, without_pi, format: :html4)
# => true
```

## Test plan

- [x] Unit specs in new `spec/canon/comparison/html_parser_spec.rb` — leading PI stripped, leading whitespace tolerated, mid-document PI left alone, existing `</head>\s*<body>` collapse still works, `parse(:html5)` produces identical fragment children with vs. without a leading PI.
- [x] Integration specs in `spec/canon/comparison/html_comparator_spec.rb` — `equivalent?` returns true with vs. without the PI under `:html4` and `:html5`.
- [x] `bundle exec rspec` — full canon suite green (2142 examples, 0 failures, 1 unrelated pending).
- [x] `bundle exec rubocop` — clean on changed files.
- [x] Verified against the original `metanorma/isodoc` `spec/isodoc/table_spec.rb:2030` reproducer: the false `<div class="main-section">` mismatch is gone. (A different assertion in the same test now exposes a *separate* content difference unrelated to canon — out of scope for this PR.)

## Documentation

`docs/understanding/formats/html.adoc` gains an "Input normalization" subsection that documents both the existing DOCTYPE strip and the new PI strip as input-boundary rules. YARD on `normalize_html_for_parsing` updated with the same content.

## Follow-up (out of scope)

`record_fragment_length_mismatch` reports the surplus *tail* of the longer side as the orphan, even when the actual extra element is at the head of the array. This is misleading when length mismatches are caused by leading nodes (as the original bug here demonstrated). Worth a separate small enhancement to compute a more informative orphan position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
