### PR TITLE
fix: align orphan locators at fragment and per-element levels (#128, #132)

### DIFF
--- a/docs/advanced/semantic-diff-report.adoc
+++ b/docs/advanced/semantic-diff-report.adoc
@@ -199,6 +199,34 @@ orphan-locator now identifies the bogus comment correctly rather than
 blaming an unrelated tail element.
 ====
 
+==== Element-aware alignment for per-element children
+
+The same two-ended alignment is applied one level deeper, in
+`XmlComparatorHelpers::ChildComparison#use_positional_comparison`,
+when comparing an element's children (issue #132).  Naive zip pairing
+broke catastrophically under inter-sibling whitespace asymmetry: a
+pretty-printed expected fixture (with `\n  ` between every `<br/>`
+and `<b>`) and a compacted received output (with no whitespace
+between siblings) misaligned at every position downstream of the
+first whitespace mismatch, producing a cascade of spurious "element
+X missing" / "text Y added" diffs at scattered positions.
+
+Element-aware alignment skips whitespace-only text nodes during the
+prefix/suffix scan: scanning advances past whitespace on each side
+independently so that the matched-element skeleton aligns even when
+the inter-element whitespace differs.  Whitespace text nodes that
+fall in the gap region surface as their own orphans (correctly named
+as text); element orphans surface as elements; nothing is hidden.
+
+For a fixture where both sides have the same 3 `<br/>` and 2 `<b>`
+elements but the expected side has whitespace text between them and
+the received does not, the report now contains diffs only for the
+asymmetric whitespace text nodes -- never for the `<br/>` or `<b>`
+elements, which are correctly identified as matched on both sides.
+
+The alignment helpers are shared between this site and the
+fragment-level mismatch reporter via `Canon::Comparison::AlignmentHelpers`.
+
 === Text Content
 
 Shows when element text differs.

--- a/docs/advanced/semantic-diff-report.adoc
+++ b/docs/advanced/semantic-diff-report.adoc
@@ -119,6 +119,86 @@ Location:   /html/body/div[@id="main"]
 ----
 ====
 
+=== Element Structure
+
+Shows when an element has been added, removed, or has a different name or
+child structure.  Nokogiri nodes and Canon nodes are both rendered as
+compact XML (issue #120), with attributes preserved and self-closing
+form for empty elements.
+
+.Example: Element name differs
+[example]
+====
+[source]
+----
+🔍 DIFFERENCE #1/1 [NORMATIVE]
+──────────────────────────────────────────────────────────────────────
+Dimension: element_structure
+Reason:  different element name (<i> vs <br>)
+
+⊖ Expected (File 1):
+   <i>Subject: non-user</i>
+⊕ Actual (File 2):
+   <br/>
+
+✨ Changes:
+   Element structure changed: <i>Subject: non-user</i> → <br/>
+----
+====
+
+The `Reason:` text uses short human-readable labels, never raw integer
+comparison codes (issue #127).  Recognised labels include:
+
+* `elements differ` (`Comparison::UNEQUAL_ELEMENTS`)
+* `node types differ` (`Comparison::UNEQUAL_NODES_TYPES`)
+* `missing` (`Comparison::MISSING_NODE`)
+* `attributes differ`, `comments differ`, `text content differs`, etc.
+
+For the most common offender — both sides being `UNEQUAL_ELEMENTS` with
+differing element names — the reason is replaced with the more specific
+`different element name (<a> vs <b>)`.
+
+==== Inserted or removed elements
+
+When one side has an element that the other side does not, the missing
+side renders as `(not present)`:
+
+[source]
+----
+🔍 DIFFERENCE #1/1 [NORMATIVE]
+──────────────────────────────────────────────────────────────────────
+Dimension: element_structure
+Reason:  missing
+
+⊖ Expected (File 1):
+   <removed>content</removed>
+⊕ Actual (File 2):
+   (not present)
+
+✨ Changes:
+   Element removed: <removed>content</removed>
+----
+
+==== Fragment-level child-count mismatches
+
+When two HTML fragments differ by one or more top-level children, Canon
+identifies the orphan region by walking aligned prefix and suffix from
+both ends of the child lists and treating the gap as the orphan set
+(issue #128).  This points the report at the *actual* offending element
+even when it sits at the head or middle of the document — the previous
+behaviour always blamed the tail of the longer side, which produced
+diffs remote from the real cause.
+
+[NOTE]
+====
+A common trigger is a leading `<?xml ?>` processing instruction in HTML
+input: `Nokogiri::HTML5.fragment` parses the PI as a bogus comment node
+which becomes a top-level fragment child.  Canon does not strip this
+input (see closed PR #124 for the maintainer's rationale), but the
+orphan-locator now identifies the bogus comment correctly rather than
+blaming an unrelated tail element.
+====
+
 === Text Content
 
 Shows when element text differs.

--- a/lib/canon/comparison/alignment_helpers.rb
+++ b/lib/canon/comparison/alignment_helpers.rb
@@ -1,0 +1,238 @@
+# frozen_string_literal: true
+
+require "set"
+
+module Canon
+  module Comparison
+    # Two-ended alignment helpers for locating orphans in child-list
+    # comparisons.
+    #
+    # Used by both:
+    # - +HtmlComparator#record_fragment_length_mismatch+ (top-level
+    #   fragment children, see lutaml/canon#128)
+    # - +XmlComparatorHelpers::ChildComparison#use_positional_comparison+
+    #   (per-element children, see lutaml/canon#132)
+    #
+    # The shape: peel off the longest aligned prefix and the longest
+    # aligned suffix between two child arrays; the gap between is the
+    # set of genuinely-different children.  Falls back gracefully to
+    # the surplus tail (or the whole longer array) when no alignment
+    # exists.  Never produces *worse* output than naive zip.
+    module AlignmentHelpers
+      module_function
+
+      # Identify the orphan region in +longer+ given the corresponding
+      # +shorter+ child list.
+      #
+      # @param longer [Array] The longer child list
+      # @param shorter [Array] The shorter child list
+      # @return [Array] Orphan child nodes from +longer+
+      def locate_orphans(longer, shorter)
+        prefix = aligned_prefix_length(longer, shorter)
+        suffix = aligned_suffix_length(longer, shorter, prefix)
+        longer[prefix...(longer.length - suffix)]
+      end
+
+      # Two-array prefix length, scanning lock-step over the parallel
+      # positions in +longer+ and +shorter+.  This is used by
+      # +locate_orphans+ to identify the orphan region in +longer+,
+      # so the prefix length is reported in *longer*'s coordinate
+      # system: it is the index in +longer+ at which alignment first
+      # breaks.
+      def aligned_prefix_length(longer, shorter)
+        i = 0
+        i += 1 while i < shorter.length && nodes_align?(longer[i],
+                                                        shorter[i])
+        i
+      end
+
+      # Two-array suffix length, scanning from the end pair-by-pair.
+      # Returned in +longer+'s coordinate system (number of trailing
+      # elements that align with the trailing elements of +shorter+),
+      # never crossing into the prefix region.
+      def aligned_suffix_length(longer, shorter, prefix)
+        i = 0
+        while i < (shorter.length - prefix) &&
+            nodes_align?(longer[longer.length - 1 - i],
+                         shorter[shorter.length - 1 - i])
+          i += 1
+        end
+        i
+      end
+
+      # Element-aware alignment: locate orphans while *ignoring*
+      # whitespace-only text nodes during the scan.  Lock-step scan
+      # advances past whitespace on either side independently, so that
+      # asymmetric inter-sibling whitespace (a pretty-printed fixture
+      # vs a compacted receiver, or vice versa) does not break the
+      # alignment after the first whitespace mismatch.  See
+      # lutaml/canon#132.
+      #
+      # The alignment is computed over the element-only skeletons of
+      # both sides, then mapped back to the original positions.
+      # Orphans = original positions of +longer+ that fall outside the
+      # aligned regions in either coordinate system.  Whitespace text
+      # nodes in the gap region surface as their own orphans; element
+      # orphans are reported as elements; nothing is hidden.
+      #
+      # @param longer [Array] Longer child list
+      # @param shorter [Array] Shorter child list
+      # @return [Array] Orphan child nodes from +longer+
+      def locate_orphans_skipping_whitespace(longer, shorter)
+        long_idx = element_indices(longer)
+        short_idx = element_indices(shorter)
+        long_elems  = long_idx.map  { |i| longer[i]  }
+        short_elems = short_idx.map { |i| shorter[i] }
+
+        # Align element-only skeletons.
+        prefix = aligned_prefix_length(long_elems, short_elems)
+        suffix = aligned_suffix_length(long_elems, short_elems, prefix)
+
+        # Map back: keep original-array positions that fall inside an
+        # aligned element pair.  Everything else in +longer+ is an
+        # orphan in this coordinate system.
+        kept = Set.new
+        prefix.times { |k| kept << long_idx[k] }
+        suffix.times { |k| kept << long_idx[long_idx.length - 1 - k] }
+
+        (0...longer.length).reject { |i| kept.include?(i) }.map do |i|
+          longer[i]
+        end
+      end
+
+      # Indices of element-typed children (non-whitespace text included
+      # for now -- only whitespace-only text nodes are skipped, since
+      # those are the noise the alignment needs to ignore).
+      def element_indices(children)
+        children.each_with_index.filter_map do |c, i|
+          next i unless whitespace_only_text?(c)
+
+          nil
+        end
+      end
+
+      # Element-aware alignment that returns both the orphan list and
+      # the aligned-position pairs in one pass.  Pairs preserve the
+      # caller's original side ordering: the returned pairs are
+      # +[children1[i], children2[j]]+ regardless of which side was
+      # the longer one in the alignment scan.
+      #
+      # @param children1 [Array] First child list
+      # @param children2 [Array] Second child list
+      # @return [Hash] +{ orphans: [...], orphan_side: :first|:second,
+      #   aligned_pairs: [[c1, c2], ...] }+
+      def align_with_pairs(children1, children2)
+        if children1.length >= children2.length
+          longer  = children1
+          shorter = children2
+          orphan_side = :first
+        else
+          longer  = children2
+          shorter = children1
+          orphan_side = :second
+        end
+
+        long_idx  = element_indices(longer)
+        short_idx = element_indices(shorter)
+        long_elems  = long_idx.map  { |i| longer[i]  }
+        short_elems = short_idx.map { |i| shorter[i] }
+
+        prefix = aligned_prefix_length(long_elems, short_elems)
+        suffix = aligned_suffix_length(long_elems, short_elems, prefix)
+
+        # Aligned-element pairs in (longer, shorter) coordinates.
+        long_paired_idx  = []
+        short_paired_idx = []
+        prefix.times do |k|
+          long_paired_idx  << long_idx[k]
+          short_paired_idx << short_idx[k]
+        end
+        suffix.times do |k|
+          long_paired_idx  << long_idx[long_idx.length - 1 - k]
+          short_paired_idx << short_idx[short_idx.length - 1 - k]
+        end
+
+        # Orphans = positions of +longer+ outside the aligned set.
+        kept = long_paired_idx.to_set
+        orphans = (0...longer.length).reject { |i| kept.include?(i) }
+          .map { |i| longer[i] }
+
+        # Pairs in (children1, children2) ordering.
+        aligned_pairs = long_paired_idx.zip(short_paired_idx)
+          .map do |li, si|
+          if orphan_side == :first
+            [longer[li], shorter[si]]
+          else
+            [shorter[si], longer[li]]
+          end
+        end
+
+        { orphans: orphans, orphan_side: orphan_side,
+          aligned_pairs: aligned_pairs }
+      end
+
+      # Whitespace-only text node test.  Used by element-aware
+      # alignment to skip cosmetic whitespace during the scan.
+      def whitespace_only_text?(node)
+        return false unless node
+
+        is_text = if node.respond_to?(:node_type) &&
+            node.node_type.is_a?(Symbol)
+                    node.node_type == :text
+                  elsif node.respond_to?(:text?)
+                    node.text?
+                  else
+                    false
+                  end
+        return false unless is_text
+
+        text = if node.respond_to?(:value)
+                 node.value
+               elsif node.respond_to?(:content)
+                 node.content
+               else
+                 ""
+               end
+        text.to_s.match?(/\A\s*\z/)
+      end
+
+      # Two nodes align for orphan-locating purposes when they have
+      # the same node kind, the same name (for elements), and the
+      # same attribute key set.  Shallow by design -- deep equality
+      # would defeat the point of running the alignment to *locate*
+      # a structural difference.
+      def nodes_align?(node_a, node_b)
+        return false unless node_a && node_b
+        return false unless same_kind?(node_a, node_b)
+
+        a_name = node_a.respond_to?(:name) ? node_a.name : nil
+        b_name = node_b.respond_to?(:name) ? node_b.name : nil
+        return false unless a_name == b_name
+
+        node_attribute_keys(node_a) == node_attribute_keys(node_b)
+      end
+
+      # Two nodes are the same "kind" when both are elements, both are
+      # text, both are comments, etc.  Uses +node_type+ when available
+      # (Canon nodes), falling back to class equality (Nokogiri
+      # nodes), so the helpers work across both DOM models.
+      def same_kind?(node_a, node_b)
+        if node_a.respond_to?(:node_type) &&
+            node_b.respond_to?(:node_type) &&
+            node_a.node_type.is_a?(Symbol) &&
+            node_b.node_type.is_a?(Symbol)
+          return node_a.node_type == node_b.node_type
+        end
+
+        node_a.instance_of?(node_b.class)
+      end
+
+      # Sorted attribute key list for a node, or [] for non-elements.
+      def node_attribute_keys(node)
+        return [] unless node.respond_to?(:attribute_nodes)
+
+        node.attribute_nodes.map { |a| a.name.to_s }.sort
+      end
+    end
+  end
+end

--- a/lib/canon/comparison/html_comparator.rb
+++ b/lib/canon/comparison/html_comparator.rb
@@ -14,6 +14,7 @@ require_relative "strategies/match_strategy_factory"
 require_relative "../html/data_model"
 require_relative "xml_node_comparison"
 require_relative "xml_comparator/diff_node_builder"
+require_relative "alignment_helpers"
 # Whitespace sensitivity module (single source of truth for sensitive elements)
 require_relative "whitespace_sensitivity"
 
@@ -205,7 +206,7 @@ module Canon
                                     [children2, children1, :added]
                                   end
 
-          orphans = locate_fragment_orphans(longer, shorter)
+          orphans = AlignmentHelpers.locate_orphans(longer, shorter)
 
           orphans.each do |orphan|
             n1 = side == :removed ? orphan : nil
@@ -219,64 +220,6 @@ module Canon
                 dimension: :element_structure,
               )
           end
-        end
-
-        # Identify the orphan region in +longer+ given the corresponding
-        # +shorter+ child list.  Walks aligned prefix and suffix from
-        # both ends; the gap between is the set of orphans.  Falls back
-        # to the whole surplus tail (the previous behaviour) when no
-        # alignment exists at either end.
-        #
-        # @param longer [Array] The longer child list
-        # @param shorter [Array] The shorter child list
-        # @return [Array] Orphan child nodes from +longer+
-        def locate_fragment_orphans(longer, shorter)
-          prefix = aligned_prefix_length(longer, shorter)
-          suffix = aligned_suffix_length(longer, shorter, prefix)
-          longer[prefix...(longer.length - suffix)]
-        end
-
-        # Longest run from the start where corresponding nodes align.
-        def aligned_prefix_length(longer, shorter)
-          i = 0
-          i += 1 while i < shorter.length && nodes_align?(longer[i],
-                                                          shorter[i])
-          i
-        end
-
-        # Longest run from the end where corresponding nodes align,
-        # never crossing into the prefix region.
-        def aligned_suffix_length(longer, shorter, prefix)
-          i = 0
-          while i < (shorter.length - prefix) &&
-              nodes_align?(longer[longer.length - 1 - i],
-                           shorter[shorter.length - 1 - i])
-            i += 1
-          end
-          i
-        end
-
-        # Two nodes align for orphan-locating purposes when they have
-        # the same node kind, the same name (for elements), and the
-        # same attribute key set.  This is intentionally a shallow
-        # check: deep equality would defeat the whole point of running
-        # the alignment to *locate* a structural difference.
-        def nodes_align?(node_a, node_b)
-          return false unless node_a && node_b
-          return false unless node_a.instance_of?(node_b.class)
-
-          a_name = node_a.respond_to?(:name) ? node_a.name : nil
-          b_name = node_b.respond_to?(:name) ? node_b.name : nil
-          return false unless a_name == b_name
-
-          node_attribute_keys(node_a) == node_attribute_keys(node_b)
-        end
-
-        # Sorted attribute key list for a node, or [] for non-elements.
-        def node_attribute_keys(node)
-          return [] unless node.respond_to?(:attribute_nodes)
-
-          node.attribute_nodes.map { |a| a.name.to_s }.sort
         end
 
         # Compare children of document fragments

--- a/lib/canon/comparison/html_comparator.rb
+++ b/lib/canon/comparison/html_comparator.rb
@@ -189,6 +189,14 @@ module Canon
         # Record a DiffNode for a fragment-level child-count mismatch.
         # Each surplus child becomes its own MISSING_NODE diff so the
         # downstream report shows what was added or removed.
+        #
+        # Orphan position is computed by a two-ended alignment scan:
+        # peel off the longest aligned prefix and the longest aligned
+        # suffix between the two child lists, and treat the gap as the
+        # orphan region.  Without this, the reporter would naively
+        # always blame the tail of the longer side, which is
+        # actively misleading when the actual extra element sits at
+        # the head or middle of the document (see lutaml/canon#128).
         def record_fragment_length_mismatch(_node1, _node2, children1,
                                             children2, differences)
           longer, shorter, side = if children1.length > children2.length
@@ -197,7 +205,9 @@ module Canon
                                     [children2, children1, :added]
                                   end
 
-          longer[shorter.length...].each do |orphan|
+          orphans = locate_fragment_orphans(longer, shorter)
+
+          orphans.each do |orphan|
             n1 = side == :removed ? orphan : nil
             n2 = side == :removed ? nil    : orphan
             differences <<
@@ -209,6 +219,64 @@ module Canon
                 dimension: :element_structure,
               )
           end
+        end
+
+        # Identify the orphan region in +longer+ given the corresponding
+        # +shorter+ child list.  Walks aligned prefix and suffix from
+        # both ends; the gap between is the set of orphans.  Falls back
+        # to the whole surplus tail (the previous behaviour) when no
+        # alignment exists at either end.
+        #
+        # @param longer [Array] The longer child list
+        # @param shorter [Array] The shorter child list
+        # @return [Array] Orphan child nodes from +longer+
+        def locate_fragment_orphans(longer, shorter)
+          prefix = aligned_prefix_length(longer, shorter)
+          suffix = aligned_suffix_length(longer, shorter, prefix)
+          longer[prefix...(longer.length - suffix)]
+        end
+
+        # Longest run from the start where corresponding nodes align.
+        def aligned_prefix_length(longer, shorter)
+          i = 0
+          i += 1 while i < shorter.length && nodes_align?(longer[i],
+                                                          shorter[i])
+          i
+        end
+
+        # Longest run from the end where corresponding nodes align,
+        # never crossing into the prefix region.
+        def aligned_suffix_length(longer, shorter, prefix)
+          i = 0
+          while i < (shorter.length - prefix) &&
+              nodes_align?(longer[longer.length - 1 - i],
+                           shorter[shorter.length - 1 - i])
+            i += 1
+          end
+          i
+        end
+
+        # Two nodes align for orphan-locating purposes when they have
+        # the same node kind, the same name (for elements), and the
+        # same attribute key set.  This is intentionally a shallow
+        # check: deep equality would defeat the whole point of running
+        # the alignment to *locate* a structural difference.
+        def nodes_align?(node_a, node_b)
+          return false unless node_a && node_b
+          return false unless node_a.instance_of?(node_b.class)
+
+          a_name = node_a.respond_to?(:name) ? node_a.name : nil
+          b_name = node_b.respond_to?(:name) ? node_b.name : nil
+          return false unless a_name == b_name
+
+          node_attribute_keys(node_a) == node_attribute_keys(node_b)
+        end
+
+        # Sorted attribute key list for a node, or [] for non-elements.
+        def node_attribute_keys(node)
+          return [] unless node.respond_to?(:attribute_nodes)
+
+          node.attribute_nodes.map { |a| a.name.to_s }.sort
         end
 
         # Compare children of document fragments

--- a/lib/canon/comparison/xml_comparator/child_comparison.rb
+++ b/lib/canon/comparison/xml_comparator/child_comparison.rb
@@ -154,70 +154,82 @@ diff_children, differences)
           end
 
           # Use simple positional comparison for children
+          #
+          # When length differs between sides, locate orphans via the
+          # same two-ended alignment scan that PR #129 added at the
+          # fragment level: peel aligned prefix and suffix from both
+          # ends, emit per-orphan diffs in the gap region, and recurse
+          # into the aligned-prefix and aligned-suffix pairs to find
+          # deeper differences.  The previous naive zip approach
+          # produced a cascade of spurious type-mismatch diffs at every
+          # position downstream of the first whitespace asymmetry; the
+          # new approach collapses those to the actual orphans (often
+          # whitespace text nodes only).  See lutaml/canon#132.
           def use_positional_comparison(
             children1, children2, _parent_node, comparator,
             opts, child_opts, diff_children, differences
           )
-            has_mismatch = false
+            has_mismatch = children1.length != children2.length
 
-            # Length check
-            unless children1.length == children2.length
-              has_mismatch = true
-              dimension = determine_dimension_for_mismatch(
-                children1, children2, comparator
-              )
+            aligned_pairs = if has_mismatch
+                              locate_orphans_and_emit(
+                                children1, children2, comparator, opts,
+                                differences
+                              )
+                            else
+                              children1.zip(children2)
+                            end
 
-              mismatched_children, children1, children2 =
-                determine_mismatch_children(
-                  children1, children2, comparator
-                )
-
-              if mismatched_children.empty?
-                comparator.send(:add_difference, parent_node, parent_node,
-                                Comparison::MISSING_NODE, Comparison::MISSING_NODE,
-                                dimension, opts, differences)
-              else
-                # Per-child dimension based on the orphan's actual node
-                # type — an element orphan must be tagged
-                # :element_structure (not the prevailing positional
-                # default) so the diff formatter renders it as the
-                # element it is, rather than as +text ""+.  See
-                # lutaml/canon#125 follow-up.
-                mismatched_children.each do |child|
-                  child_dim = comparator.send(:determine_node_dimension,
-                                              child)
-                  if children1.length > children2.length # rubocop:disable Metrics/BlockNesting
-                    comparator.send(:add_difference, child, nil,
-                                    Comparison::MISSING_NODE,
-                                    Comparison::MISSING_NODE,
-                                    child_dim, opts, differences)
-                  else
-                    comparator.send(:add_difference, nil, child,
-                                    Comparison::MISSING_NODE,
-                                    Comparison::MISSING_NODE,
-                                    child_dim, opts, differences)
-                  end
-                end
-              end
-              # Continue comparing children to find deeper differences like attribute values
-              # Use zip to compare up to the shorter length
-            end
-
-            # Compare children pairwise by position
+            # Compare aligned pairs deeply for content / attribute
+            # differences.
             result = has_mismatch ? Comparison::UNEQUAL_ELEMENTS : Comparison::EQUIVALENT
-            children1.zip(children2).each do |child1, child2|
-              # Skip if one is nil (due to different lengths)
+            aligned_pairs.each do |child1, child2|
               next if child1.nil? || child2.nil?
 
               child_result = comparator.send(:compare_nodes, child1, child2,
-                                             child_opts, child_opts, diff_children, differences)
-
-              unless child_result == Comparison::EQUIVALENT
-                result = child_result
-              end
+                                             child_opts, child_opts,
+                                             diff_children, differences)
+              result = child_result unless child_result == Comparison::EQUIVALENT
             end
 
             result
+          end
+
+          # Use AlignmentHelpers (element-aware, whitespace-skipping)
+          # to find orphans and emit per-orphan diffs with per-orphan
+          # dimension.  Returns the aligned-position pairs in
+          # (children1, children2) ordering for the caller to recurse
+          # into.
+          #
+          # @return [Array<Array(Object, Object)>] aligned (child1, child2) pairs
+          def locate_orphans_and_emit(children1, children2, comparator, opts,
+                                       differences)
+            require_relative "../alignment_helpers"
+
+            alignment = AlignmentHelpers.align_with_pairs(children1, children2)
+
+            alignment[:orphans].each do |orphan|
+              # Per-child dimension based on the orphan's actual node
+              # type — an element orphan must be tagged
+              # :element_structure (not the prevailing positional
+              # default) so the diff formatter renders it as the
+              # element it is, rather than as +text ""+.  See
+              # lutaml/canon#125 follow-up.
+              child_dim = comparator.send(:determine_node_dimension, orphan)
+              if alignment[:orphan_side] == :first
+                comparator.send(:add_difference, orphan, nil,
+                                Comparison::MISSING_NODE,
+                                Comparison::MISSING_NODE,
+                                child_dim, opts, differences)
+              else
+                comparator.send(:add_difference, nil, orphan,
+                                Comparison::MISSING_NODE,
+                                Comparison::MISSING_NODE,
+                                child_dim, opts, differences)
+              end
+            end
+
+            alignment[:aligned_pairs]
           end
 
           # Determine dimension for length mismatch

--- a/spec/canon/comparison/html_comparator_spec.rb
+++ b/spec/canon/comparison/html_comparator_spec.rb
@@ -481,5 +481,70 @@ RSpec.describe Canon::Comparison::HtmlComparator do
         expect(changes).not_to include("</div>")
       end
     end
+
+    context "fragment orphan position (issue #128)" do
+      # When fragments differ by one extra top-level child, the orphan
+      # locator must identify the actual offending element by walking
+      # aligned prefix and suffix from both ends of the child lists.
+      # The previous behaviour always blamed the *tail* of the longer
+      # side, which produced misleading diffs whenever the real
+      # disruption sat at the head or middle of the document.
+      def fetch_structural_diffs(left, right)
+        result = Canon::Comparison.equivalent?(left, right, format: :html5,
+                                                            verbose: true)
+        result.differences.grep(Canon::Diff::DiffNode).select do |d|
+          d.dimension == :element_structure
+        end
+      end
+
+      it "reports the head element when the extra is at the head" do
+        without_meta = <<~HTML
+          <html>
+            <head><style></style></head>
+            <body>
+              <div class="WordSection2">A</div>
+              <p><br clear="all" class="section"/></p>
+              <div class="WordSection3"><aside id="ftn1"><p>X</p></aside></div>
+            </body>
+          </html>
+        HTML
+        with_meta = without_meta.sub(
+          "<head><style></style></head>",
+          %(<head><meta http-equiv="Content-Type" ) +
+            %(content="text/html; charset=UTF-8"/><style></style></head>),
+        )
+
+        diffs = fetch_structural_diffs(without_meta, with_meta)
+        expect(diffs).not_to be_empty
+
+        orphan_node = diffs.first.node1 || diffs.first.node2
+        expect(orphan_node.respond_to?(:name) && orphan_node.name)
+          .to eq("meta")
+      end
+
+      it "reports the middle element when the extra is at the middle" do
+        left  = "<div>A</div><p>B</p><span>D</span>"
+        right = "<div>A</div><p>B</p><section>C</section><span>D</span>"
+
+        diffs = fetch_structural_diffs(left, right)
+        expect(diffs).not_to be_empty
+
+        orphan_node = diffs.first.node1 || diffs.first.node2
+        expect(orphan_node.name).to eq("section")
+      end
+
+      it "still reports the tail element when the extra is at the tail" do
+        # Regression guard for the previous behaviour, which is correct
+        # for tail-only insertions and must keep working.
+        left  = "<div>A</div><p>B</p>"
+        right = "<div>A</div><p>B</p><span>C</span>"
+
+        diffs = fetch_structural_diffs(left, right)
+        expect(diffs).not_to be_empty
+
+        orphan_node = diffs.first.node1 || diffs.first.node2
+        expect(orphan_node.name).to eq("span")
+      end
+    end
   end
 end

--- a/spec/canon/comparison/html_comparator_spec.rb
+++ b/spec/canon/comparison/html_comparator_spec.rb
@@ -546,5 +546,62 @@ RSpec.describe Canon::Comparison::HtmlComparator do
         expect(orphan_node.name).to eq("span")
       end
     end
+
+    context "per-element child alignment under whitespace asymmetry (issue #132)" do
+      # Both sides have the same elements (3 brs, 2 bs).  The only
+      # difference is inter-sibling whitespace text nodes that exist in
+      # one fixture and not the other.  The diff report must NOT name
+      # any of the brs as "missing" — they're all present on both
+      # sides.  Whitespace text nodes can surface as their own
+      # diffs, but element orphans must not be invented.
+      it "does not report element orphans when only whitespace text differs" do
+        expected = <<~HTML
+          <div><h1 class="Annex">
+            <b><b>Aldono</b> A</b>
+            <br/>
+            (normative)
+            <br/>
+            <br/>
+            <b>Annex</b>
+          </h1></div>
+        HTML
+        received = "<div><h1 class=\"Annex\">" \
+                   "<b><b>Aldono</b> A</b><br/>(normative)" \
+                   "<br/><br/><b>Annex</b></h1></div>"
+
+        result = Canon::Comparison.equivalent?(expected, received,
+                                               format: :html5, verbose: true)
+
+        diffs = result.differences.grep(Canon::Diff::DiffNode)
+        element_names = %w[br b].freeze
+        element_orphan_diffs = diffs.select do |d|
+          n = d.node1 || d.node2
+          n.respond_to?(:name) && element_names.include?(n.name) &&
+            (d.node1.nil? || d.node2.nil?)
+        end
+
+        expect(element_orphan_diffs).to be_empty,
+                                        "no <br> or <b> orphan should be " \
+                                        "reported (count is the same on " \
+                                        "both sides), got: #{element_orphan_diffs.map(&:reason)}"
+      end
+
+      it "still surfaces real element orphans when an element is genuinely missing" do
+        expected = "<root><a/><b/><c/></root>"
+        received = "<root><a/><c/></root>"
+
+        result = Canon::Comparison.equivalent?(expected, received,
+                                               format: :html5, verbose: true)
+
+        diffs = result.differences.grep(Canon::Diff::DiffNode)
+        b_orphan_diffs = diffs.select do |d|
+          n = d.node1 || d.node2
+          n.respond_to?(:name) && n.name == "b"
+        end
+
+        expect(b_orphan_diffs).not_to be_empty,
+                                      "missing <b> should still be reported"
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #128. Closes #132.

## Base

This PR is **stacked on top of #126** (`fix/125-text-content-nil-side-rendering`). Please review and merge #126 first; this PR will rebase onto `main` once that lands.

## Summary

Two related orphan-locator bugs, both in the same family (structurally disruptive child-list shape → misleading report remote from the actual cause):

### #128 — Fragment-level orphan-locator blames the tail

`HtmlComparator#record_fragment_length_mismatch` always picked the surplus *tail* of the longer side as the orphan region. Correct only when the extra element actually is the last one. For an insertion at the head or middle of the fragment-child list, the suffix and the real extra element sit at opposite ends — the report blamed innocent tail elements.

Real-world bite: HTML inputs whose head injects a charset `<meta>` (and similarly, leading `<?xml ?>` PIs that `Nokogiri::HTML5.fragment` parses as bogus comments and hoists to fragment top level) consistently produced `Element added: <div class="WordSection3">` diffs at the very end of the document, with no hint the actual offence was a tag near the start.

**Fix**: replace the naive suffix slice with a two-ended alignment scan. Walk aligned prefix and suffix from both ends, treat the gap as the orphan region. Falls back gracefully to current behaviour when no alignment exists at either end.

### #132 — Per-element child comparison cascades under whitespace asymmetry

`XmlComparatorHelpers::ChildComparison#use_positional_comparison` zipped two child arrays naively and reported a per-position diff at every position where they disagreed on type. Under inter-sibling whitespace asymmetry — the common case where a pretty-printed expected fixture has whitespace text nodes between `<br/>` and `<b>` siblings and the compacted received output has none — every position downstream of the first whitespace mismatch reported a type clash. The user was told 5 different things were wrong when the only difference was inter-sibling whitespace.

**Fix**: apply the same two-ended alignment one level deeper, with two refinements:

1. **Element-aware**: whitespace-only text nodes are skipped during the prefix/suffix scan, so the alignment locates the matched-element skeleton even when inter-element whitespace differs. Whitespace text nodes in the gap region still surface as their own diffs — nothing is hidden.

2. **Side-preserving**: aligned-position pairs use `(children1[i], children2[j])` ordering regardless of which side was longer, so `compare_nodes` always receives expected on the left and received on the right.

The alignment helpers move from `HtmlComparator` to a shared `Canon::Comparison::AlignmentHelpers` module so both sites consume the same logic.

## Before / after

### #128 — head-orphan reproducer

Two HTML fragments differing only by a `<meta http-equiv>` injected into `<head>`:

```diff
- ⊕ Actual: <div class="WordSection3"><aside id="ftn1"><p>X</p></aside></div>
+ ⊕ Actual: <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
```

### #132 — whitespace-asymmetry reproducer

Two HTML fragments with the same elements (3 `<br/>`, 2 `<b>`, 1 text node) but different inter-sibling whitespace:

```diff
- 5 NORMATIVE diffs: "element missing: br", "Text: vs (normative)", ...
+ 4 NORMATIVE diffs: all about specific whitespace text nodes; no br reported missing
```

Verified end-to-end against `metanorma/isodoc` `spec/isodoc/postproc_word_spec.rb:1081` (#128 reproducer) and `spec/isodoc/i18n_spec.rb:2178` (#132 reproducer).

## Documentation

`docs/advanced/semantic-diff-report.adoc` gains:

- "Element Structure" dimension section covering Nokogiri-aware rendering (carried from #120 / merged PR #121, was undocumented), human-readable Reason labels (#127, on parent branch #126), and the #128 fix.
- "Element-aware alignment for per-element children" sub-subsection documenting the #132 fix.
- "One-sided text diffs" sub-subsection (originally added on parent #126).

## Test plan

- [x] New integration specs in [`spec/canon/comparison/html_comparator_spec.rb`](https://github.com/lutaml/canon/blob/fix/128-fragment-orphan-position/spec/canon/comparison/html_comparator_spec.rb) for both #128 (head/middle/tail orphan position) and #132 (whitespace asymmetry, real-element-orphan regression guard).
- [x] `bundle exec rspec` — full canon suite green (2163 examples, 0 failures, 1 unrelated pending).
- [x] `bundle exec rubocop` — clean on changed Ruby files.

## Differentiation from prior threads

- **Not** issue #120 / PR #121 (merged): rendering of correctly-identified orphan nodes. This PR is about *identification*.
- **Not** issue #122 / PR #124 (closed): input normalisation. This PR does not normalise anything.
- **Not** issue #125 / PR #126 (this PR is stacked on #126): different code path entirely. PR #126 fixed `:text_content` one-sided rendering and reason-label leakage. This PR fixes orphan-location at two levels of granularity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
