### PR TITLE
fix: surface XML/HTML parse errors at the top of the diff report (#130)

### DIFF
--- a/docs/advanced/semantic-diff-report.adoc
+++ b/docs/advanced/semantic-diff-report.adoc
@@ -14,6 +14,39 @@ The Semantic Diff Report provides dimension-specific, actionable details for eac
 
 The report is automatically shown in verbose mode when differences exist, appearing before the detailed diff output.
 
+== Parse errors
+
+When Canon's underlying parser (libxml for XML, HTML5 for HTML) reports errors during input parsing, Canon surfaces them at the top of the diff report in a banner section before any per-difference output. The banner names the offending side and warns that the diff below describes the parsed tree, not the input — content the parser could not represent has been silently dropped from the comparison tree.
+
+This is purely a transparency feature: Canon does not modify the parse to "fix" invalid input. The user is responsible for deciding whether the parse failure was expected (e.g. testing legacy fixtures during a migration) or symptomatic of an upstream bug.
+
+.Example: Banner for a duplicate-attribute FATAL on the received side
+[example]
+====
+[source]
+----
+======================================================================
+  ⚠️  PARSE ERRORS
+======================================================================
+  Received side:
+    Attribute xml:lang redefined
+
+  ⚠️  The diff below describes the parsed tree, not the input.
+      Content that the parser could not represent has been
+      dropped and may appear as "missing" in the report.
+======================================================================
+----
+====
+
+Common triggers in HTML / XHTML round-trips:
+
+* Duplicate attributes (XML strict; HTML5 permissive — only XML mode triggers a banner)
+* Stray processing instructions in fragment context
+* Malformed namespace declarations
+* DOCTYPE in unexpected positions
+
+The banner is rendered when `Canon::Comparison::ComparisonResult#parse_errors?` is true. Programmatic callers can read `parse_errors_expected` and `parse_errors_received` directly off the result.
+
 == Key Features
 
 * XPath locations for XML/HTML elements

--- a/lib/canon/comparison.rb
+++ b/lib/canon/comparison.rb
@@ -122,6 +122,34 @@ module Canon
     UNEQUAL_TYPES = 15
     UNEQUAL_PRIMITIVES = 16
 
+    # Extract parse-time errors from a parsed-tree or Nokogiri-fragment
+    # node, regardless of which parser produced it.  Used by the
+    # comparators to plumb libxml's error list through to
+    # +ComparisonResult+ so the diff report can surface FATAL parse
+    # conditions that would otherwise silently drop content from the
+    # comparison tree.  See lutaml/canon#130.
+    #
+    # @param node [Object, nil] Parsed node (Canon::Xml::Node, Nokogiri
+    #   fragment/document, or nil)
+    # @return [Array<String>] Parse errors as strings (empty by default)
+    def self.parse_errors_for(node)
+      return [] if node.nil?
+
+      # Canon::Xml::Node carries errors via the parse_errors accessor.
+      if node.respond_to?(:parse_errors)
+        errors = node.parse_errors
+        return Array(errors).map(&:to_s) if errors && !errors.empty?
+      end
+
+      # Nokogiri::XML::Document, Nokogiri::HTML5::DocumentFragment etc.
+      # expose errors natively.
+      if node.respond_to?(:errors)
+        return Array(node.errors).map(&:to_s)
+      end
+
+      []
+    end
+
     class << self
       # Auto-detect format and compare two objects
       #

--- a/lib/canon/comparison/comparison_result.rb
+++ b/lib/canon/comparison/comparison_result.rb
@@ -6,7 +6,8 @@ module Canon
     # Provides methods to query equivalence based on normative diffs
     class ComparisonResult
       attr_reader :differences, :preprocessed_strings, :format, :html_version,
-                  :match_options, :algorithm, :original_strings
+                  :match_options, :algorithm, :original_strings,
+                  :parse_errors_expected, :parse_errors_received
 
       # @param differences [Array<DiffNode>] Array of difference nodes
       # @param preprocessed_strings [Array<String, String>] Pre-processed content for display
@@ -15,8 +16,11 @@ module Canon
       # @param match_options [Hash, nil] Resolved match options used for comparison
       # @param algorithm [Symbol] Diff algorithm used (:dom or :semantic)
       # @param original_strings [Array<String, String>, nil] Original unprocessed content for line diff
+      # @param parse_errors_expected [Array<String>, nil] Parser errors from the expected side
+      # @param parse_errors_received [Array<String>, nil] Parser errors from the received side
       def initialize(differences:, preprocessed_strings:, format:,
-html_version: nil, match_options: nil, algorithm: :dom, original_strings: nil)
+html_version: nil, match_options: nil, algorithm: :dom, original_strings: nil,
+parse_errors_expected: nil, parse_errors_received: nil)
         @differences = differences
         @preprocessed_strings = preprocessed_strings
         @original_strings = original_strings || preprocessed_strings
@@ -24,6 +28,16 @@ html_version: nil, match_options: nil, algorithm: :dom, original_strings: nil)
         @html_version = html_version
         @match_options = match_options
         @algorithm = algorithm
+        @parse_errors_expected = Array(parse_errors_expected)
+        @parse_errors_received = Array(parse_errors_received)
+      end
+
+      # Whether either side reported parse errors.  Used by the diff
+      # formatter to decide whether to render the parse-error banner.
+      #
+      # @return [Boolean]
+      def parse_errors?
+        @parse_errors_expected.any? || @parse_errors_received.any?
       end
 
       # Check if documents are semantically equivalent (no normative diffs)

--- a/lib/canon/comparison/html_comparator.rb
+++ b/lib/canon/comparison/html_comparator.rb
@@ -151,6 +151,8 @@ module Canon
               html_version: detect_html_version_from_node(node1),
               match_options: match_opts_hash,
               algorithm: :dom,
+              parse_errors_expected: Comparison.parse_errors_for(node1),
+              parse_errors_received: Comparison.parse_errors_for(node2),
             )
           elsif result != Comparison::EQUIVALENT && !differences.empty?
             # Non-verbose mode: check equivalence
@@ -300,6 +302,8 @@ module Canon
               html_version: html_version,
               match_options: match_opts_hash.merge(strategy.metadata),
               algorithm: :semantic,
+              parse_errors_expected: Comparison.parse_errors_for(node1),
+              parse_errors_received: Comparison.parse_errors_for(node2),
             )
           else
             # Simple boolean result - equivalent if no normative differences

--- a/lib/canon/comparison/xml_comparator.rb
+++ b/lib/canon/comparison/xml_comparator.rb
@@ -160,6 +160,8 @@ module Canon
               format: :xml,
               match_options: match_opts_hash,
               algorithm: :dom,
+              parse_errors_expected: Comparison.parse_errors_for(node1),
+              parse_errors_received: Comparison.parse_errors_for(node2),
             )
           elsif result != Comparison::EQUIVALENT && !differences.empty?
             # Non-verbose mode: check equivalence
@@ -222,6 +224,8 @@ module Canon
               format: :xml,
               match_options: match_opts_hash.merge(strategy.metadata),
               algorithm: :semantic,
+              parse_errors_expected: Comparison.parse_errors_for(node1),
+              parse_errors_received: Comparison.parse_errors_for(node2),
             )
           else
             # Simple boolean result - equivalent if no normative differences

--- a/lib/canon/diff_formatter.rb
+++ b/lib/canon/diff_formatter.rb
@@ -392,6 +392,18 @@ module Canon
         output << "" # Blank line for spacing
       end
 
+      # Parse-error banner.  When libxml flagged any errors during
+      # parsing, surface them at the top of the report so the user
+      # is not left chasing diffs that describe a partial tree.
+      # See lutaml/canon#130.
+      if comparison_result.is_a?(Canon::Comparison::ComparisonResult) &&
+          comparison_result.parse_errors?
+        output << format_parse_error_banner(
+          comparison_result.parse_errors_expected,
+          comparison_result.parse_errors_received,
+        )
+      end
+
       # 1. CANON VERBOSE tables (ONLY if CANON_VERBOSE=1)
       verbose_tables = DebugOutput.verbose_tables_only(
         comparison_result,
@@ -506,6 +518,53 @@ module Canon
     end
 
     private
+
+    # Render the parse-error banner that appears at the top of the
+    # diff report when libxml flagged any errors during parsing.
+    # Names the offending side(s) and warns that the diff below
+    # describes the parsed tree, not the input.  See lutaml/canon#130.
+    #
+    # @param errors_expected [Array<String>] Errors from the expected side
+    # @param errors_received [Array<String>] Errors from the received side
+    # @return [String] Multi-line banner
+    def format_parse_error_banner(errors_expected, errors_received)
+      lines = []
+      rule = "=" * 70
+      lines << colorize(rule, :yellow, :bold)
+      lines << colorize("  ⚠️  PARSE ERRORS", :yellow, :bold)
+      lines << colorize(rule, :yellow, :bold)
+
+      if errors_expected.any?
+        lines << colorize("  Expected side:", :yellow, :bold)
+        errors_expected.each do |err|
+          lines << "    #{colorize(err, :red)}"
+        end
+      end
+
+      if errors_received.any?
+        lines << colorize("  Received side:", :yellow, :bold)
+        errors_received.each do |err|
+          lines << "    #{colorize(err, :red)}"
+        end
+      end
+
+      lines << ""
+      lines << colorize(
+        "  ⚠️  The diff below describes the parsed tree, not the input.",
+        :yellow,
+      )
+      lines << colorize(
+        "      Content that the parser could not represent has been",
+        :yellow,
+      )
+      lines << colorize(
+        "      dropped and may appear as \"missing\" in the report.",
+        :yellow,
+      )
+      lines << colorize(rule, :yellow, :bold)
+      lines << ""
+      lines.join("\n")
+    end
 
     # Normalize content for display in diffs
     #

--- a/lib/canon/xml/data_model.rb
+++ b/lib/canon/xml/data_model.rb
@@ -31,7 +31,20 @@ module Canon
         check_for_relative_namespace_uris(doc)
 
         # Convert to XPath data model
-        build_from_nokogiri(doc, preserve_whitespace: preserve_whitespace)
+        result = build_from_nokogiri(doc,
+                                     preserve_whitespace: preserve_whitespace)
+
+        # Carry libxml's parse errors on the resulting tree so the diff
+        # report can surface them (see lutaml/canon#130).  libxml's
+        # FATAL conditions (e.g. duplicate attributes) silently drop
+        # content from the parse tree; without surfacing the error
+        # list, downstream diffs describe the partial tree, not the
+        # input.
+        errors = Array(doc.errors).map(&:to_s)
+        result.parse_errors = errors if errors.any? &&
+          result.respond_to?(:parse_errors=)
+
+        result
       end
 
       # Normalize XML string encoding to UTF-8

--- a/lib/canon/xml/node.rb
+++ b/lib/canon/xml/node.rb
@@ -24,6 +24,21 @@ module Canon
         @in_node_set = value
       end
 
+      # Parse-time errors carried alongside the node tree, captured at
+      # parse boundaries (Canon::Xml::DataModel.from_xml, etc.) so the
+      # diff report can surface libxml-level FATAL conditions that
+      # would otherwise be silently swallowed and produce misleading
+      # diffs against a partially-loaded tree.  See lutaml/canon#130.
+      #
+      # @return [Array<String>] Parse errors as strings (empty by default)
+      def parse_errors
+        instance_variable_defined?(:@parse_errors) ? @parse_errors : []
+      end
+
+      def parse_errors=(value)
+        @parse_errors = Array(value)
+      end
+
       # Return the text content of this node and all descendants.
       # ElementNode concatenates children's text_content; other nodes
       # (TextNode, CommentNode, etc.) return their value.

--- a/lib/canon/xml/sax_builder.rb
+++ b/lib/canon/xml/sax_builder.rb
@@ -93,6 +93,23 @@ strip_doctype: false)
         # Track in-scope namespaces at each level
         # Each entry is a hash of prefix => uri
         @namespace_stack = [build_initial_namespaces]
+        # Captured libxml errors during SAX parsing.  Surfaced on the
+        # resulting RootNode so the diff report can warn the user
+        # when a FATAL parse error has caused content loss
+        # (see lutaml/canon#130).
+        @parse_errors = []
+      end
+
+      # SAX callbacks for libxml errors and warnings.  Without these
+      # overrides the default handlers swallow the events; with them,
+      # libxml's "Attribute xml:lang redefined" and similar messages
+      # land in @parse_errors and ride through to ComparisonResult.
+      def error(string)
+        @parse_errors << string.to_s.strip
+      end
+
+      def warning(string)
+        @parse_errors << string.to_s.strip
       end
 
       # Called when an element starts
@@ -229,6 +246,7 @@ strip_doctype: false)
         # followed by PIs and comments outside the document element
         # (C14N requires this ordering)
         reorder_children(@root)
+        @root.parse_errors = @parse_errors if @parse_errors.any?
         @root
       end
 

--- a/spec/canon/comparison/parse_error_surface_spec.rb
+++ b/spec/canon/comparison/parse_error_surface_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "canon/diff_formatter"
+
+# Issue #130: Canon's XML parser silently drops content on FATAL libxml
+# errors (e.g. duplicate-attribute violations).  The diff layer then
+# reports against a parse tree that no longer represents the input,
+# producing reports that read as nonsense to the user.  This spec
+# exercises the parse-error surface that propagates libxml's error list
+# all the way to ComparisonResult and the diff banner.
+RSpec.describe "parse error surface (issue #130)" do
+  let(:formatter) { Canon::DiffFormatter.new(use_color: false) }
+
+  describe "duplicate xml:lang in XML mode" do
+    let(:expected) do
+      '<body lang="en" xml:lang="en"><div class="x">x</div></body>'
+    end
+    let(:received) do
+      '<body lang="en" xml:lang="en" xml:lang="en"><div class="x">x</div></body>'
+    end
+    let(:result) do
+      Canon::Comparison.equivalent?(expected, received,
+                                    format: :xml, verbose: true)
+    end
+
+    it "surfaces the libxml FATAL on the received side" do
+      expect(result.parse_errors_received).not_to be_empty
+      expect(result.parse_errors_received.join("\n"))
+        .to match(/Attribute xml:lang redefined/)
+    end
+
+    it "leaves the expected side's parse_errors empty" do
+      expect(result.parse_errors_expected).to eq([])
+    end
+
+    it "answers parse_errors? truthfully" do
+      expect(result.parse_errors?).to be true
+    end
+
+    it "renders a banner at the top of the diff report" do
+      output = formatter.format_comparison_result(result, expected, received)
+      banner_line = output.lines.find { |l| l.include?("⚠️  PARSE ERRORS") }
+      expect(banner_line).not_to be_nil
+      expect(output).to include("Received side:")
+      expect(output).to include("Attribute xml:lang redefined")
+      expect(output)
+        .to include("describes the parsed tree, not the input")
+    end
+
+    it "renders the banner before the semantic diff section" do
+      output = formatter.format_comparison_result(result, expected, received)
+      banner_idx = output.index("PARSE ERRORS")
+      report_idx = output.index("SEMANTIC DIFF REPORT")
+      expect(banner_idx).not_to be_nil
+      expect(report_idx).not_to be_nil
+      expect(banner_idx).to be < report_idx
+    end
+  end
+
+  describe "valid XML on both sides" do
+    let(:expected) { "<root><a>1</a><b>2</b></root>" }
+    let(:received) { "<root><a>1</a><b>3</b></root>" }
+    let(:result) do
+      Canon::Comparison.equivalent?(expected, received,
+                                    format: :xml, verbose: true)
+    end
+
+    it "leaves both parse_errors arrays empty" do
+      expect(result.parse_errors_expected).to eq([])
+      expect(result.parse_errors_received).to eq([])
+    end
+
+    it "answers parse_errors? false" do
+      expect(result.parse_errors?).to be false
+    end
+
+    it "does not render a banner" do
+      output = formatter.format_comparison_result(result, expected, received)
+      expect(output).not_to include("PARSE ERRORS")
+    end
+  end
+
+  describe "duplicate attribute in HTML5 mode (no error to surface)" do
+    let(:expected) do
+      '<body lang="en" xml:lang="en"><div>x</div></body>'
+    end
+    let(:received) do
+      '<body lang="en" xml:lang="en" xml:lang="en"><div>x</div></body>'
+    end
+
+    it "does not record a parse error (HTML5 dedupes silently per spec)" do
+      result = Canon::Comparison.equivalent?(expected, received,
+                                             format: :html5, verbose: true)
+      expect(result.parse_errors_expected).to eq([])
+      expect(result.parse_errors_received).to eq([])
+      expect(result.parse_errors?).to be false
+    end
+  end
+end

--- a/spec/canon/diff_formatter/diff_detail_formatter_spec.rb
+++ b/spec/canon/diff_formatter/diff_detail_formatter_spec.rb
@@ -508,7 +508,7 @@ RSpec.describe "DiffDetailFormatter helpers" do
       comparison_result = double("comparison_result")
       allow(comparison_result).to receive(:is_a?).with(Canon::Comparison::ComparisonResult).and_return(true)
       allow(comparison_result).to receive_messages(algorithm: :dom,
-                                                   differences: [diff], equivalent?: false, original_strings: ["<root/>", "<root/>"], html_version: nil, match_options: nil)
+                                                   differences: [diff], equivalent?: false, original_strings: ["<root/>", "<root/>"], html_version: nil, match_options: nil, parse_errors?: false, parse_errors_expected: [], parse_errors_received: [])
 
       output = formatter.format_comparison_result(comparison_result, "<root/>",
                                                   "<root/>")
@@ -572,7 +572,7 @@ RSpec.describe "DiffDetailFormatter helpers" do
       comparison_result = double("comparison_result")
       allow(comparison_result).to receive(:is_a?).with(Canon::Comparison::ComparisonResult).and_return(true)
       allow(comparison_result).to receive_messages(algorithm: :dom,
-                                                   differences: [diff], equivalent?: false, original_strings: ["<root/>", "<root/>"], html_version: nil, match_options: nil)
+                                                   differences: [diff], equivalent?: false, original_strings: ["<root/>", "<root/>"], html_version: nil, match_options: nil, parse_errors?: false, parse_errors_expected: [], parse_errors_received: [])
 
       output = formatter.format_comparison_result(comparison_result, "<root/>",
                                                   "<root/>")


### PR DESCRIPTION
Closes #130.

## Summary

When libxml flags a FATAL condition during input parsing — most commonly a duplicate-attribute violation in XHTML round-trips, but also stray PIs and malformed namespace declarations — Canon's parser silently drops content and runs the comparison against a tree that no longer represents the input. The diff report then describes the *parsed tree*, naming elements as "missing" that the user can plainly see in the raw text. The pretty-print stub at the bottom of the report is the only place the actual cause is visible, and only if the user knows to look there.

This PR surfaces libxml's error list at the parse boundary, propagates it through `ComparisonResult`, and renders a banner at the top of the diff report so the user is told *immediately* that they are looking at a partial tree.

**Not a normalisation change.** The parse itself is unchanged. Canon does not "fix" the duplicate attribute or strip the stray PI. The error list is information libxml already produced — Canon was discarding it. This is a transparency fix, not behavioural.

## Before / after

For two HTML/XHTML strings differing by a single duplicate `xml:lang="en"` on the received `<body>`:

**Before:**
```
SEMANTIC DIFF REPORT (1 difference)
…
Reason:  element 'body': missing
⊖ Expected (File 1): (not present)
⊕ Actual (File 2)  : text "" in
```

The body is right there in the received string. Diagnosing this requires direct `Nokogiri::XML(received).errors` probing — which a Canon user should not need to do.

**After:**
```
======================================================================
  ⚠️  PARSE ERRORS
======================================================================
  Received side:
    Attribute xml:lang redefined

  ⚠️  The diff below describes the parsed tree, not the input.
      Content that the parser could not represent has been
      dropped and may appear as "missing" in the report.
======================================================================

SEMANTIC DIFF REPORT (1 difference)
…
```

The user reads the banner, knows the diff below is against a partial tree, and can stop chasing phantoms.

## Implementation

* [lib/canon/xml/node.rb](lib/canon/xml/node.rb) — add `parse_errors` accessor on the base `Canon::Xml::Node` class (default `[]`). Propagates to `RootNode` and other subclasses.
* [lib/canon/xml/sax_builder.rb](lib/canon/xml/sax_builder.rb) — override `error` and `warning` SAX callbacks (previously swallowed by `Nokogiri::XML::SAX::Document` defaults). Capture into `@parse_errors`, attach to the resulting `RootNode` in `result`.
* [lib/canon/xml/data_model.rb](lib/canon/xml/data_model.rb) — read `doc.errors` after `Nokogiri::XML(...)` returns, before the document is discarded; attach to the resulting `RootNode`.
* [lib/canon/comparison.rb](lib/canon/comparison.rb) — new `Canon::Comparison.parse_errors_for(node)` helper handles both Canon nodes (`parse_errors` accessor) and Nokogiri fragments/documents (native `errors`).
* [lib/canon/comparison/comparison_result.rb](lib/canon/comparison/comparison_result.rb) — new `parse_errors_expected` / `parse_errors_received` fields plus `parse_errors?` predicate.
* [lib/canon/comparison/xml_comparator.rb](lib/canon/comparison/xml_comparator.rb) and [lib/canon/comparison/html_comparator.rb](lib/canon/comparison/html_comparator.rb) — propagate from parsed nodes to `ComparisonResult`.
* [lib/canon/diff_formatter.rb](lib/canon/diff_formatter.rb) — new `format_parse_error_banner` helper, called from `format_comparison_result` between the algorithm display and the `SEMANTIC DIFF REPORT`.

## Test plan

- [x] New `spec/canon/comparison/parse_error_surface_spec.rb` — duplicate `xml:lang` reproducer (asserts errors captured, banner rendered above the semantic diff section), valid-XML control (asserts no banner), HTML5 mode reproducer (asserts no banner — HTML5 parser dedupes silently per spec, no error to surface).
- [x] Existing `spec/canon/diff_formatter/diff_detail_formatter_spec.rb` mocks updated to stub the new accessors. No behavioural changes there.
- [x] `bundle exec rspec` — full canon suite green (2143 examples, 0 failures, 1 unrelated pending).
- [x] `bundle exec rubocop` — clean on changed files.

## Anticipated objection

I expect the maintainer's first reaction will mirror #122: "not Canon's problem — make your input valid." With respect, that response would be wrong here, for a different reason than #122 was.

#122 asked Canon to *normalise* a leading `<?xml ?>` PI out of HTML input — to silently swallow a structural input quirk. The maintainer rejected that on the principle that Canon should not hide differences. Reasonable.

This PR does the opposite. Canon already runs `Nokogiri::XML.parse`. libxml already produces an error list. Canon is the only thing in the chain that *discards* that list before showing the user the diff. The current behaviour is **silent content loss** — the worst category of error reporting, because the report looks confident and rendered while pointing at a tree that does not match the input. That is strictly worse than either normalising (which at least produces a comparable tree) or refusing (which at least signals failure).

The user in the failing case is mid-fixture-migration on a substantial real-world codebase — exactly the workflow where Canon's diff reports are most heavily relied on. "Make your input valid" is not actionable advice when the entire purpose of running the comparison is to *discover* that the input has changed. The diff report is the diagnostic surface; when that surface is silently corrupted, Canon is failing at its core job.

This is the same family of bug as #122 (silent index shift on PI) and #128 (head-orphan locator): **structurally disruptive input produces misleading reports remote from the actual cause.** #128 fixed the report to point at the right node when Nokogiri merely *shifts* indices. This issue is the case where Nokogiri *deletes* content. The principle is identical — Canon's report must remain interpretable in the face of input shapes that disturb the parse.

The fix here neither modifies the parse nor hides any difference. It surfaces information the parser already produced, in a clearly-labelled banner, so the user can decide whether the parse failure was expected (legacy fixture migration) or symptomatic (upstream bug). That decision has to be the user's. But they need to be told it happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
