### PR TITLE
fix: actually indent HTML in fixture-ready pretty-print (#133)

### DIFF
--- a/docs/reference/environment-variables.adoc
+++ b/docs/reference/environment-variables.adoc
@@ -194,7 +194,9 @@ export CANON_JSON_FORMAT_PREPROCESSING=normalize
 |`CANON_SHOW_PRETTYPRINT_RECEIVED`
 |boolean
 |`false`
-|Show only the RECEIVED (actual) block in the fixture-ready pretty-printed section.  This is the most common fixture-update workflow: enable this option to get a copy-pasteable pretty-printed form of the generated output that can replace the old fixture heredoc.  Format-specific: `CANON_{FORMAT}_DIFF_SHOW_PRETTYPRINT_RECEIVED`
+|Show only the RECEIVED (actual) block in the fixture-ready pretty-printed section.  This is the most common fixture-update workflow: enable this option to get a copy-pasteable pretty-printed form of the generated output that can replace the old fixture heredoc.  Format-specific: `CANON_{FORMAT}_DIFF_SHOW_PRETTYPRINT_RECEIVED`.
+
+For HTML / HTML4 / HTML5 inputs, the pretty-printed output is XHTML-shaped: void elements are self-closed (`<br/>`, `<meta/>`), non-void elements are paired (`<a></a>`), and Nokogiri may add `xmlns="http://www.w3.org/1999/xhtml"` on `<html>` and an `xml:lang` mirror of `lang`.  This is a display-only serialisation chosen because libxml's `FORMAT` save flag (the only path that actually indents HTML5 input) requires the XHTML save mode -- `Nokogiri::HTML5#to_html` silently ignores its `indent:` keyword.  See lutaml/canon#133.
 |All formats (display only)
 
 |`CANON_COMPACT_SEMANTIC_REPORT`

--- a/lib/canon/diff_formatter.rb
+++ b/lib/canon/diff_formatter.rb
@@ -931,9 +931,13 @@ module Canon
 
       if %i[html html4 html5].include?(format)
         require "canon/pretty_printer/html"
+        # Fixture-ready mode actually indents (libxml FORMAT save flag
+        # via AS_XHTML).  The default mode is structurally faithful but
+        # does not indent on HTML5 input -- see lutaml/canon#133.
         printer = Canon::PrettyPrinter::Html.new(
           indent: @pretty_printer_indent,
           indent_type: indent_type_str,
+          fixture_ready: true,
         )
       elsif format == :xml
         require "canon/pretty_printer/xml"

--- a/lib/canon/pretty_printer/html.rb
+++ b/lib/canon/pretty_printer/html.rb
@@ -1,18 +1,42 @@
 # frozen_string_literal: true
 
 require "nokogiri"
+require "stringio"
 
 module Canon
   module PrettyPrinter
     # Pretty printer for HTML with consistent indentation
+    #
+    # Two modes:
+    #
+    # 1. Default mode (+fixture_ready: false+): retains the existing
+    #    behaviour for callers that use the pretty-printer as a
+    #    structural normaliser (the canon round-trip tests, the
+    #    diff-pipeline +apply_pretty_print+ stage, etc).  These callers
+    #    do not require actual indentation; they require structural
+    #    equivalence to the input.
+    #
+    # 2. Fixture-ready mode (+fixture_ready: true+): emits
+    #    actually-indented XHTML-shaped output via libxml's +FORMAT+
+    #    save flag.  Used by +DiffFormatter#prettyprint_for_display+
+    #    (the +CANON_<FORMAT>_DIFF_SHOW_PRETTYPRINT_RECEIVED+ surface)
+    #    so the user can read or paste the formatted output directly
+    #    into a fixture heredoc.  Output is XHTML-shaped (void
+    #    elements self-closed, non-void paired) and prefixed with
+    #    +<?xml ...?>+; this is a display-only serialisation.
+    #
+    # See lutaml/canon#133.
     class Html
-      def initialize(indent: 2, indent_type: "space")
+      def initialize(indent: 2, indent_type: "space", fixture_ready: false)
         @indent = indent.to_i
         @indent_type = indent_type
+        @fixture_ready = fixture_ready
       end
 
       # Pretty print HTML with consistent indentation
       def format(html_string)
+        return format_fixture_ready(html_string) if @fixture_ready
+
         # Detect if this is XHTML or HTML
         if xhtml?(html_string)
           format_as_xhtml(html_string)
@@ -51,6 +75,34 @@ module Canon
         else
           doc.to_html(indent: @indent, encoding: "UTF-8")
         end
+      end
+
+      # Fixture-ready serialisation: parse with Nokogiri::HTML5 (so we
+      # get permissive recovery on real-world Word / XHTML5 / HTML5
+      # input shapes), then write through libxml's XML writer with
+      # +FORMAT+ + +AS_XHTML+ + +NO_DECLARATION+.  +FORMAT+ inserts
+      # indentation; +AS_XHTML+ produces well-shaped output (void
+      # elements self-closed, non-void paired) which is the format
+      # users want to paste into a fixture heredoc.  +NO_DECLARATION+
+      # suppresses the +<?xml ...?>+ prefix that libxml otherwise
+      # emits in XML-writer mode.
+      def format_fixture_ready(html_string)
+        doc = Nokogiri::HTML5(html_string)
+        io = StringIO.new
+        if @indent_type == "tab"
+          doc.write_to(io, save_with: fixture_ready_save_options,
+                           indent: 1, indent_text: "\t")
+        else
+          doc.write_to(io, save_with: fixture_ready_save_options,
+                           indent: @indent)
+        end
+        io.string
+      end
+
+      def fixture_ready_save_options
+        Nokogiri::XML::Node::SaveOptions::FORMAT |
+          Nokogiri::XML::Node::SaveOptions::AS_XHTML |
+          Nokogiri::XML::Node::SaveOptions::NO_DECLARATION
       end
     end
   end

--- a/spec/canon/pretty_printer/html_spec.rb
+++ b/spec/canon/pretty_printer/html_spec.rb
@@ -77,5 +77,71 @@ RSpec.describe Canon::PrettyPrinter::Html do
         expect(result).to include("nested content")
       end
     end
+
+    # Issue #133: Nokogiri::HTML5#to_html silently ignored the
+    # +indent:+ option, producing a single-line blob inside the
+    # PRETTY-PRINTED INPUTS section.  These specs lock the new
+    # +fixture_ready: true+ mode that uses
+    # +write_to(save_with: FORMAT|AS_XHTML|NO_DECLARATION)+ to
+    # actually indent.  The default (non-fixture-ready) mode is
+    # untouched -- existing callers that depend on its
+    # structurally-faithful behaviour are unaffected.
+    context "indentation behaviour (issue #133)" do
+      subject { described_class.new(indent: 2, fixture_ready: true) }
+
+      it "indents Word-flavoured HTML5 input (no XHTML doctype, no default xmlns)" do
+        # Real-world reproducer: Word output starts with
+        # `<html xmlns:epub="..." lang="en">` — no XHTML DOCTYPE, no
+        # `xmlns="http://www.w3.org/1999/xhtml"` declaration.  Before
+        # the fix, this took the broken format_as_html branch.
+        input = '<html xmlns:epub="http://www.idpf.org/2007/ops" ' \
+                'lang="en"><head><meta http-equiv="Content-Type" ' \
+                'content="text/html; charset=UTF-8"/></head>' \
+                '<body><div class="WordSection2">' \
+                '<p class="page-break"><br clear="all"/></p></div></body></html>'
+
+        result = subject.format(input)
+
+        # Multiple lines.
+        expect(result.lines.length).to be > 5
+        # At least one indented child element.
+        expect(result).to match(/\n  </)
+        # The original <body>'s children appear on separate lines
+        # rather than as a single blob.
+        expect(result).to match(/<body[^>]*>\s*\n\s+</)
+      end
+
+      it "indents plain HTML5 doctype input" do
+        input = "<!DOCTYPE html>\n" \
+                "<html><body><div><p>x</p></div></body></html>"
+
+        result = subject.format(input)
+
+        expect(result.lines.length).to be > 5
+        expect(result).to match(/<body>\s*\n\s+<div>/)
+        expect(result).to match(/<div>\s*\n\s+<p>/)
+      end
+
+      it "indents XHTML-shaped input" do
+        input = "<html xmlns=\"http://www.w3.org/1999/xhtml\">" \
+                "<body><p>x</p></body></html>"
+
+        result = subject.format(input)
+
+        expect(result.lines.length).to be > 3
+        expect(result).to match(/<body>\s*\n\s+<p>/)
+      end
+
+      it "preserves element count through the round-trip" do
+        # A cheap regression guard: the serializer must not drop
+        # content during pretty-print.
+        input = "<html xmlns:epub=\"x\" lang=\"en\">" \
+                "<body><div><p>a</p><p>b</p><p>c</p></div></body></html>"
+        result = subject.format(input)
+
+        out_count = Nokogiri::XML(result).search("p").length
+        expect(out_count).to eq(3)
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #133.

## Summary

`CANON_HTML_DIFF_SHOW_PRETTYPRINT_RECEIVED=true` correctly activated the standalone PRETTY-PRINTED INPUTS section in the diff report, but the *content* inside was a single-line blob, not pretty-printed at all. The header advertises "Fixture-ready" but the content was unchanged from the raw input.

Cause: [`Canon::PrettyPrinter::Html`](https://github.com/lutaml/canon/blob/main/lib/canon/pretty_printer/html.rb)'s `format_as_html` branch ran `Nokogiri::HTML5(html).to_html(indent: 2)`. **`Nokogiri::HTML5#to_html` silently ignores the `indent:` keyword** and emits the document as a single line. The other branch (`format_as_xhtml`, used when an XHTML DOCTYPE or `xmlns="http://www.w3.org/1999/xhtml"` was sniffed) does indent because it routes through `to_xml(indent:)`. Real-world Word-flavoured HTML5 inputs trigger neither sniff and land on the broken path.

This PR adds a `fixture_ready: false / true` mode to `Html.new`:

- **Default mode** (`fixture_ready: false`): unchanged. Used by canon round-trip tests, the diff-pipeline `apply_pretty_print` stage, and other structural-normalisation callers. These callers do not require actual indentation; they require structural equivalence to the input. Their behaviour is preserved exactly.
- **Fixture-ready mode** (`fixture_ready: true`): parses with `Nokogiri::HTML5`, then writes through libxml's XML writer with `FORMAT | AS_XHTML | NO_DECLARATION` save flags. `FORMAT` inserts indentation; `AS_XHTML` produces well-shaped output (void elements self-closed, non-void paired); `NO_DECLARATION` suppresses the `<?xml...?>` prefix. Output is XHTML-shaped — this is a display-only serialisation chosen because libxml's `FORMAT` only honours indentation in XML-writer mode.

`DiffFormatter#prettyprint_for_display` (the only path that produces user-facing fixture-update output, gated by `CANON_*_DIFF_SHOW_PRETTYPRINT_RECEIVED`) is wired to pass `fixture_ready: true`. All other callers stay on the structurally-faithful default.

## Before / after

For Word-flavoured HTML5 input (`<html xmlns:epub="..." lang="en"><head>…</head><body>…</body></html>`):

**Before:**
```
=== PRETTY-PRINTED INPUTS (Fixture-ready) ===
RECEIVED:
----------------------------------------------------------------------
<html xmlns:epub="..." lang="en"><head><meta...><style>...</style></head><body>…</body></html>
```
(Single line — the `indent:` option is silently ignored.)

**After:**
```
=== PRETTY-PRINTED INPUTS (Fixture-ready) ===
RECEIVED:
----------------------------------------------------------------------
<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="..." lang="en" xml:lang="en">
  <head>
    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
  </head>
  <body>
    <div class="WordSection2">
      <p class="page-break">
        <br clear="all" />
      </p>
    </div>
  </body>
</html>
```

Verified end-to-end via direct probe of `DiffFormatter#format_comparison_result` with `show_prettyprint_received: true`.

## Test plan

- [x] New specs in [`spec/canon/pretty_printer/html_spec.rb`](https://github.com/lutaml/canon/blob/fix/133-html-prettyprint-indent/spec/canon/pretty_printer/html_spec.rb): Word-flavoured HTML5 input, plain HTML5 doctype input, XHTML-shaped input, element-count regression guard. All assert proper indentation in fixture-ready mode.
- [x] Existing 6 specs in `html_spec.rb` still pass (default mode is unchanged).
- [x] `bundle exec rspec` — full canon suite green (2138 examples, 0 failures, 1 unrelated pending).
- [x] `bundle exec rubocop` — clean on changed files.

## Differentiation from prior threads

- Independent of all open / closed canon threads (#120, #121, #122, #124, #125, #126, #127, #128, #129, #130, #131, #132). Different file, different code path, different layer of the stack.
- Branched off `main`. Ready to merge as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
