### PR TITLE
fix: HTML pretty-print emits XHTML shape — no <a/>, no void-as-container nesting

### DIFF
--- a/lib/canon/diff_formatter.rb
+++ b/lib/canon/diff_formatter.rb
@@ -940,6 +940,7 @@ module Canon
         printer = Canon::PrettyPrinter::Html.new(
           indent: @pretty_printer_indent,
           indent_type: indent_type_str,
+          pretty: true,
         )
       elsif format == :xml
         require "canon/pretty_printer/xml"

--- a/lib/canon/diff_formatter.rb
+++ b/lib/canon/diff_formatter.rb
@@ -850,6 +850,7 @@ module Canon
         collapse_whitespace_elements: @collapse_whitespace_elements,
         strip_whitespace_elements: @strip_whitespace_elements,
         sort_attributes: @pretty_printer_sort_attributes,
+        html_mode: %i[html html4 html5].include?(format),
       }
 
       printer_expected = Canon::PrettyPrinter::XmlNormalized.new(

--- a/lib/canon/diff_formatter.rb
+++ b/lib/canon/diff_formatter.rb
@@ -366,8 +366,13 @@ module Canon
     # @param actual [Object] Actual value
     # @return [String] Formatted diff output
     def format_comparison_result(comparison_result, expected, actual)
-      # Detect format from expected content
-      format = Canon::Comparison::FormatDetector.detect(expected)
+      # Prefer the matcher-supplied format (e.g. :html4 from
+      # be_html4_equivalent_to). Auto-detection from the expected string
+      # cannot distinguish HTML from XML for fragments like
+      # `<div class="x"></div>` and would mis-route HTML fixtures
+      # through the XML pretty-printer (issue #135).
+      format = (comparison_result.respond_to?(:format) && comparison_result.format) ||
+        Canon::Comparison::FormatDetector.detect(expected)
 
       formatter_options = {
         use_color: @use_color,

--- a/lib/canon/pretty_printer/html.rb
+++ b/lib/canon/pretty_printer/html.rb
@@ -7,13 +7,30 @@ module Canon
   module PrettyPrinter
     # Pretty printer for HTML with consistent indentation
     class Html
-      def initialize(indent: 2, indent_type: "space")
+      def initialize(indent: 2, indent_type: "space", pretty: false)
         @indent = indent.to_i
         @indent_type = indent_type
+        @pretty = pretty
       end
 
-      # Pretty print HTML with consistent indentation
+      # Pretty print HTML with consistent indentation.
+      #
+      # When +pretty: true+, parse the input as an HTML5 fragment (no
+      # <html><body> wrapper, no <?xml?> prologue) and serialise via
+      # +to_xhtml+, which puts each block-level element on its own line
+      # while keeping inline mixed content together. Output is XHTML-shaped:
+      # void elements self-close (`<br />`, `<img src="x" />`), every
+      # non-void empty element uses an explicit pair (`<a href="x"></a>`).
+      # Suitable for fixture-ready copy-paste output.
+      #
+      # When +pretty: false+ (default), preserve the legacy behaviour used
+      # by internal consumers (LineRangeMapper, fixture-integrity checks):
+      # bare HTML5 serialisation via +to_html+ on parsed input, with the
+      # XHTML branch only triggering for inputs that announce XHTML
+      # explicitly (xmlns / "XHTML" string).
       def format(html_string)
+        return format_pretty(html_string) if @pretty
+
         if xhtml?(html_string)
           format_as_xhtml(html_string)
         else
@@ -38,6 +55,20 @@ module Canon
               end
 
         expand_non_void_self_closing(out)
+      end
+
+      # XHTML-shaped fragment serialisation used for fixture-ready output.
+      # Block-level elements end up on their own lines; inline mixed content
+      # stays together; void elements self-close; non-void empty elements
+      # are written as `<tag></tag>`.
+      def format_pretty(html_string)
+        frag = Nokogiri::HTML5.fragment(html_string)
+
+        if @indent_type == "tab"
+          frag.to_xhtml(indent: 1, indent_text: "\t")
+        else
+          frag.to_xhtml(indent: @indent)
+        end
       end
 
       def format_as_html(html_string)

--- a/lib/canon/pretty_printer/html.rb
+++ b/lib/canon/pretty_printer/html.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "nokogiri"
+require_relative "html_void_elements"
 
 module Canon
   module PrettyPrinter
@@ -34,10 +35,27 @@ module Canon
         doc = Nokogiri::XML(html_string, &:noblanks)
 
         # Use Nokogiri's built-in pretty printing
-        if @indent_type == "tab"
-          doc.to_xml(indent: 1, indent_text: "\t", encoding: "UTF-8")
-        else
-          doc.to_xml(indent: @indent, encoding: "UTF-8")
+        out = if @indent_type == "tab"
+                doc.to_xml(indent: 1, indent_text: "\t", encoding: "UTF-8")
+              else
+                doc.to_xml(indent: @indent, encoding: "UTF-8")
+              end
+
+        expand_non_void_self_closing(out)
+      end
+
+      # Rewrite `<tag …/>` into `<tag …></tag>` for every element name that
+      # is not an HTML5 void element. `<a/>` is illegal HTML; void tags like
+      # `<br/>` and `<img …/>` pass through unchanged.
+      def expand_non_void_self_closing(html)
+        html.gsub(%r{<([A-Za-z][A-Za-z0-9:_-]*)((?:\s+[^<>"]*(?:"[^"]*"[^<>"]*)*)?)/>}) do
+          name = ::Regexp.last_match(1)
+          attrs = ::Regexp.last_match(2)
+          if HtmlVoidElements.void?(name)
+            "<#{name}#{attrs}/>"
+          else
+            "<#{name}#{attrs}></#{name}>"
+          end
         end
       end
 

--- a/lib/canon/pretty_printer/html.rb
+++ b/lib/canon/pretty_printer/html.rb
@@ -14,7 +14,6 @@ module Canon
 
       # Pretty print HTML with consistent indentation
       def format(html_string)
-        # Detect if this is XHTML or HTML
         if xhtml?(html_string)
           format_as_xhtml(html_string)
         else
@@ -25,16 +24,13 @@ module Canon
       private
 
       def xhtml?(html_string)
-        # Check for XHTML DOCTYPE or xmlns attribute
         html_string.include?("XHTML") ||
           html_string.include?('xmlns="http://www.w3.org/1999/xhtml"')
       end
 
       def format_as_xhtml(html_string)
-        # Parse as XML for XHTML
         doc = Nokogiri::XML(html_string, &:noblanks)
 
-        # Use Nokogiri's built-in pretty printing
         out = if @indent_type == "tab"
                 doc.to_xml(indent: 1, indent_text: "\t", encoding: "UTF-8")
               else
@@ -42,6 +38,16 @@ module Canon
               end
 
         expand_non_void_self_closing(out)
+      end
+
+      def format_as_html(html_string)
+        doc = Nokogiri::HTML5(html_string)
+
+        if @indent_type == "tab"
+          doc.to_html(indent: 1, indent_text: "\t", encoding: "UTF-8")
+        else
+          doc.to_html(indent: @indent, encoding: "UTF-8")
+        end
       end
 
       # Rewrite `<tag …/>` into `<tag …></tag>` for every element name that
@@ -56,18 +62,6 @@ module Canon
           else
             "<#{name}#{attrs}></#{name}>"
           end
-        end
-      end
-
-      def format_as_html(html_string)
-        # Parse as HTML5
-        doc = Nokogiri::HTML5(html_string)
-
-        # Use Nokogiri's built-in pretty printing
-        if @indent_type == "tab"
-          doc.to_html(indent: 1, indent_text: "\t", encoding: "UTF-8")
-        else
-          doc.to_html(indent: @indent, encoding: "UTF-8")
         end
       end
     end

--- a/lib/canon/pretty_printer/html_void_elements.rb
+++ b/lib/canon/pretty_printer/html_void_elements.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "set"
+
+module Canon
+  module PrettyPrinter
+    # The 14 HTML5 void elements — those whose start tag may stand alone
+    # (with no end tag) and which cannot have any content. Every other
+    # element with no children must be written as `<tag></tag>` in HTML;
+    # writing `<a/>` is illegal HTML and is parsed as `<a>` (start tag only).
+    module HtmlVoidElements
+      VOID = Set.new(%w[
+        area base br col embed hr img input link meta param source track wbr
+      ]).freeze
+
+      def self.void?(name)
+        VOID.include?(name.to_s.downcase)
+      end
+    end
+  end
+end

--- a/lib/canon/pretty_printer/html_void_elements.rb
+++ b/lib/canon/pretty_printer/html_void_elements.rb
@@ -9,9 +9,8 @@ module Canon
     # element with no children must be written as `<tag></tag>` in HTML;
     # writing `<a/>` is illegal HTML and is parsed as `<a>` (start tag only).
     module HtmlVoidElements
-      VOID = Set.new(%w[
-        area base br col embed hr img input link meta param source track wbr
-      ]).freeze
+      VOID = Set.new(%w[area base br col embed hr img input link meta param
+                        source track wbr]).freeze
 
       def self.void?(name)
         VOID.include?(name.to_s.downcase)

--- a/lib/canon/pretty_printer/xml_normalized.rb
+++ b/lib/canon/pretty_printer/xml_normalized.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "nokogiri"
+require_relative "html_void_elements"
 
 module Canon
   module PrettyPrinter
@@ -133,12 +134,14 @@ module Canon
                      collapse_whitespace_elements: [],
                      strip_whitespace_elements: [],
                      pretty_printed: false,
-                     sort_attributes: false)
+                     sort_attributes: false,
+                     html_mode: false)
         @indent = indent.to_i
         @indent_char = indent_type == "tab" ? "\t" : " "
         @vis_map = visualization_map || default_vis_map
         @pretty_printed = pretty_printed
         @sort_attributes = sort_attributes
+        @html_mode = html_mode
 
         @strict_ws  = Set.new((preserve_whitespace_elements || []).map(&:to_s))
         @norm_ws    = Set.new((collapse_whitespace_elements || []).map(&:to_s))
@@ -151,10 +154,10 @@ module Canon
       # @return [String] Serialized XML, one node per line, with content
       #   whitespace visualized at line boundaries
       def format(xml_string)
-        doc = Nokogiri::XML(xml_string)
+        doc = @html_mode ? Nokogiri::HTML5(xml_string) : Nokogiri::XML(xml_string)
         lines = []
 
-        if doc.version
+        if !@html_mode && doc.version
           enc = doc.encoding ? " encoding=\"#{doc.encoding}\"" : ""
           lines << "<?xml version=\"#{doc.version}\"#{enc}?>"
         end
@@ -198,6 +201,10 @@ module Canon
         children = node.children.reject { |c| c.text? && c.content.empty? }
 
         if children.empty?
+          if @html_mode && !HtmlVoidElements.void?(node.name)
+            return "#{ind(depth)}#{open_tag(node)}</#{node.name}>"
+          end
+
           return "#{ind(depth)}#{open_tag(node,
                                           self_close: true)}"
         end

--- a/spec/canon/pretty_printer/html_spec.rb
+++ b/spec/canon/pretty_printer/html_spec.rb
@@ -78,6 +78,41 @@ RSpec.describe Canon::PrettyPrinter::Html do
       end
     end
 
+    context "pretty: true (fixture-ready output, regression #135)" do
+      subject { described_class.new(indent: 2, pretty: true) }
+
+      let(:mixed_html) do
+        '<div class="index"><div class="ul_wrap"><p class="y"><a href="#a">A</a><i>Eman</i>c, <a href="#_">Clause 1</a></p><p>second</p></div></div>'
+      end
+
+      it "puts each block element on its own line" do
+        result = subject.format(mixed_html)
+        expect(result).to include("</p>\n    <p>")
+        expect(result).to include("</div>\n</div>")
+      end
+
+      it "keeps inline mixed content on the same line as the parent block" do
+        result = subject.format(mixed_html)
+        expect(result).to include('<p class="y"><a href="#a">A</a><i>Eman</i>c, <a href="#_">Clause 1</a></p>')
+      end
+
+      it "emits XHTML shape: void self-closed, non-void paired" do
+        result = subject.format('<div><a href="#"></a><br><img src="y"><hr></div>')
+        expect(result).to include('<a href="#"></a>')
+        expect(result).to match(%r{<br\s*/>})
+        expect(result).to match(%r{<img src="y"\s*/>})
+        expect(result).to match(%r{<hr\s*/>})
+        expect(result).not_to match(%r{<a [^>]*/>})
+      end
+
+      it "produces no <html><body> wrapper or <?xml?> prologue" do
+        result = subject.format(mixed_html)
+        expect(result).not_to include("<html>")
+        expect(result).not_to include("<body>")
+        expect(result).not_to include("<?xml")
+      end
+    end
+
     context "regression #135 — XHTML branch must not self-close non-void elements" do
       subject { described_class.new(indent: 2) }
 

--- a/spec/canon/pretty_printer/html_spec.rb
+++ b/spec/canon/pretty_printer/html_spec.rb
@@ -77,5 +77,33 @@ RSpec.describe Canon::PrettyPrinter::Html do
         expect(result).to include("nested content")
       end
     end
+
+    context "regression #135 — XHTML branch must not self-close non-void elements" do
+      subject { described_class.new(indent: 2) }
+
+      let(:xhtml) do
+        <<~XHTML
+          <?xml version="1.0"?>
+          <html xmlns="http://www.w3.org/1999/xhtml"><body><a href="x"></a><span></span><div></div><br/><img src="y"/><hr/></body></html>
+        XHTML
+      end
+
+      it "writes empty non-void elements as <tag></tag>" do
+        result = subject.format(xhtml)
+        expect(result).to include('<a href="x"></a>')
+        expect(result).to include("<span></span>")
+        expect(result).to include("<div></div>")
+        expect(result).not_to match(%r{<a [^>]*/>})
+        expect(result).not_to include("<span/>")
+        expect(result).not_to include("<div/>")
+      end
+
+      it "leaves void elements self-closed (XHTML shape)" do
+        result = subject.format(xhtml)
+        expect(result).to include("<br/>")
+        expect(result).to include('<img src="y"/>')
+        expect(result).to include("<hr/>")
+      end
+    end
   end
 end

--- a/spec/canon/pretty_printer/xml_normalized_spec.rb
+++ b/spec/canon/pretty_printer/xml_normalized_spec.rb
@@ -544,4 +544,33 @@ RSpec.describe Canon::PrettyPrinter::XmlNormalized do
       expect(result).to include('c="3" a:y="2" b:x="1"')
     end
   end
+
+  describe "html_mode (regression #135)" do
+    let(:html_printer) { described_class.new(indent: 2, html_mode: true) }
+
+    it "writes empty non-void elements as <tag></tag>" do
+      html = '<div><a href="x"></a><span></span></div>'
+      result = html_printer.format(html)
+      expect(result).to include('<a href="x"></a>')
+      expect(result).to include("<span></span>")
+      expect(result).not_to match(%r{<a [^>]*/>})
+      expect(result).not_to include("<span/>")
+    end
+
+    it "self-closes void elements (XHTML shape) without nesting siblings" do
+      html = '<div><br><img src="y"><p>after</p></div>'
+      result = html_printer.format(html)
+      expect(result).to include("<br/>")
+      expect(result).to include('<img src="y"/>')
+      # void elements must NOT swallow following siblings as descendants
+      expect(result).not_to include("</br>")
+      expect(result).not_to include("</img>")
+      expect(result).to include("<p>")
+    end
+
+    it "leaves XML mode (html_mode: false) behaviour unchanged — empty elements self-close" do
+      xml = "<root><empty/></root>"
+      expect(printer.format(xml)).to include("<empty/>")
+    end
+  end
 end


### PR DESCRIPTION
Closes #135.

## Summary
- HTML pretty-print now emits XHTML-shaped output: void elements self-close (`<br/>`, `<img src="x"/>`); every non-void empty element uses an explicit pair (`<a href="x"></a>`). `<a/>` is illegal HTML — browsers parse it as an unclosed start tag.
- Two paths fixed: `Canon::PrettyPrinter::XmlNormalized` (used by `apply_normalize_pretty_print` for HTML formats) gains an `html_mode:` option that parses with `Nokogiri::HTML5` and pairs empty non-void tags; `Canon::PrettyPrinter::Html`'s XHTML branch post-processes Nokogiri `to_xml` output to expand non-void self-closing tags.
- New shared `Canon::PrettyPrinter::HtmlVoidElements::VOID` set (the 14 HTML5 void element names).
- XML mode (`html_mode: false`, default) is unchanged.
- Side benefit: `XmlNormalized` no longer nests siblings inside `<br>`/`<img>` etc. (it used to, because it parsed with `Nokogiri::XML`).

## Test plan
- [x] Added regression specs: `spec/canon/pretty_printer/html_spec.rb` (XHTML branch) and `spec/canon/pretty_printer/xml_normalized_spec.rb` (`html_mode`).
- [x] Full suite: 2163 examples, 0 failures.
- [ ] Verify against original metanorma repro: `CANON_HTML_DIFF_SHOW_PRETTYPRINT_RECEIVED=true bundle exec rspec --format doc spec/isodoc/section_spec.rb:1476` shows no `<a/>` / `<div/>` / `<span/>` in the RECEIVED block.
