### PR TITLE
fix: parse errors, HTML pretty-print, XHTML shape, whitespace adjacency (issues #130, #133, #135, #137)

### DIFF
--- a/docs/advanced/semantic-diff-report.adoc
+++ b/docs/advanced/semantic-diff-report.adoc
@@ -14,6 +14,39 @@ The Semantic Diff Report provides dimension-specific, actionable details for eac
 
 The report is automatically shown in verbose mode when differences exist, appearing before the detailed diff output.
 
+== Parse errors
+
+When Canon's underlying parser (libxml for XML, HTML5 for HTML) reports errors during input parsing, Canon surfaces them at the top of the diff report in a banner section before any per-difference output. The banner names the offending side and warns that the diff below describes the parsed tree, not the input — content the parser could not represent has been silently dropped from the comparison tree.
+
+This is purely a transparency feature: Canon does not modify the parse to "fix" invalid input. The user is responsible for deciding whether the parse failure was expected (e.g. testing legacy fixtures during a migration) or symptomatic of an upstream bug.
+
+.Example: Banner for a duplicate-attribute FATAL on the received side
+[example]
+====
+[source]
+----
+======================================================================
+  ⚠️  PARSE ERRORS
+======================================================================
+  Received side:
+    Attribute xml:lang redefined
+
+  ⚠️  The diff below describes the parsed tree, not the input.
+      Content that the parser could not represent has been
+      dropped and may appear as "missing" in the report.
+======================================================================
+----
+====
+
+Common triggers in HTML / XHTML round-trips:
+
+* Duplicate attributes (XML strict; HTML5 permissive — only XML mode triggers a banner)
+* Stray processing instructions in fragment context
+* Malformed namespace declarations
+* DOCTYPE in unexpected positions
+
+The banner is rendered when `Canon::Comparison::ComparisonResult#parse_errors?` is true. Programmatic callers can read `parse_errors_expected` and `parse_errors_received` directly off the result.
+
 == Key Features
 
 * XPath locations for XML/HTML elements

--- a/docs/features/diff-formatting/index.adoc
+++ b/docs/features/diff-formatting/index.adoc
@@ -28,6 +28,9 @@ Canon's diff formatting includes:
 * **Context and grouping**: Control how much surrounding context to show
 * **Algorithm-specific output**: Different output styles for different diff
   algorithms
+* **Whitespace adjacency**: Stray whitespace-only text nodes are anchored at
+  themselves instead of cascading into mismatches against neighbouring
+  content (link:./whitespace-adjacency.adoc[details])
 
 == Available formatting options
 

--- a/docs/features/diff-formatting/whitespace-adjacency.adoc
+++ b/docs/features/diff-formatting/whitespace-adjacency.adoc
@@ -1,0 +1,140 @@
+---
+title: Whitespace adjacency in diff reports
+parent: Diff Formatting
+nav_order: 8
+---
+= Whitespace adjacency in diff reports
+:toc:
+:toclevels: 2
+
+== Purpose
+
+Canon's diff reports anchor whitespace-only text nodes that have no
+counterpart on the other side to a dedicated `:whitespace_adjacency`
+dimension instead of letting them cascade into 3-4 misaligned
+`:text_content` mismatches against neighbouring content nodes.
+
+This is a *report-only* contract — equivalence verdicts are unchanged.
+Inputs that were non-equivalent before this feature remain non-equivalent;
+only the *shape* of the diff report changes.
+
+== The problem
+
+Consider an HTML fragment compared as `be_html_equivalent_to`:
+
+[source,html]
+----
+<!-- expected -->
+<p>
+  <span>ISO </span>
+  <span>20483</span>
+  ,
+  <i>Cereals and pulses</i>
+</p>
+
+<!-- actual -->
+<p><span>ISO </span><span>20483</span>, <i>Cereals and pulses</i></p>
+----
+
+Both render identically in a browser — the indentation is structural HTML
+formatting, not content. Before this feature, the diff report contained
+four entries:
+
+[source]
+----
+DIFFERENCE #1 — element_structure: parent <p> "missing children"
+DIFFERENCE #2 — text_content: ""  vs  "20483"        (visualised: ↵░░░░)
+DIFFERENCE #3 — text_content: "20483"  vs  ","
+DIFFERENCE #4 — text_content: ","  vs  "Cereals and pulses"
+----
+
+The cascade comes from positional `zip()` alignment in
+`Canon::Comparison::XmlComparatorHelpers::ChildComparison`: with the
+expected side carrying extra whitespace-only text nodes and the actual
+side carrying none, every child slides by one slot and gets paired
+against the wrong neighbour.
+
+== The contract
+
+When `ChildComparison` aligns child sequences and encounters a
+whitespace-only text node on one side paired against a non-whitespace
+node on the other, it:
+
+1. Treats the whitespace node as a *single-side gap* in the alignment.
+2. Emits one `:whitespace_adjacency` diff entry anchored at the
+   whitespace node itself (not at its mis-paired neighbour).
+3. Advances only the cursor that carries the whitespace, so the next
+   iteration aligns content against content.
+
+The asymmetric whitespace still produces a non-equivalent verdict — the
+`:whitespace_adjacency` dimension is classified as normative
+unconditionally — so any test that previously failed on whitespace
+asymmetry continues to fail.
+
+After the new contract, the cascade above collapses to:
+
+[source]
+----
+DIFFERENCE #1 — whitespace_adjacency: Whitespace surrounding "20483":
+                  present on EXPECTED ("↵░░"), absent on ACTUAL
+DIFFERENCE #2 — whitespace_adjacency: Whitespace surrounding ",":
+                  present on EXPECTED ("↵░░"), absent on ACTUAL
+DIFFERENCE #3 — text_content: "↵░░,↵░░"  vs  ", "
+----
+
+== Adjacency positions
+
+The Reason line names the adjacency position of the whitespace node
+relative to its non-whitespace siblings:
+
+`:preceding`::  Whitespace at the start of its parent (no non-whitespace
+sibling before it, has one after it).
+
+`:following`::  Whitespace at the end of its parent (has a non-whitespace
+sibling before it, none after).
+
+`:surrounding`::  Sandwiched between two non-whitespace siblings.
+
+`:isolated`::  No non-whitespace siblings at all (degenerate; rarely
+emitted).
+
+== What this contract does NOT do
+
+* **Does not change equivalence outcomes.** A non-equivalent comparison
+  before #137 remains non-equivalent after — only the diff-report shape
+  changes.
+* **Does not silently filter whitespace.** The asymmetric whitespace is
+  always reported; it is just labelled `:whitespace_adjacency` and
+  anchored at the whitespace node, instead of cascading as
+  `:text_content` against unrelated content nodes.
+* **Does not affect symmetric whitespace.** When both sides carry
+  parallel whitespace-only nodes, those compare normally
+  (no `:whitespace_adjacency` entry, no cascade).
+
+== Where it runs
+
+The contract is implemented as a re-alignment walk inside
+`Canon::Comparison::XmlComparatorHelpers::ChildComparison.use_positional_comparison`.
+It activates whenever the existing positional `zip()` alignment would
+pair a whitespace-only text node against a content node — that is, in
+every whitespace context where the upstream filter has not already
+dropped the whitespace nodes.
+
+For elements where whitespace is preserved by configuration
+(`preserve_whitespace_elements`) the upstream filter does not drop
+indentation, and the re-alignment walk surfaces every asymmetric
+whitespace node as a single normative `:whitespace_adjacency` diff.
+
+== Related
+
+* link:../../advanced/diff-classification.adoc[Diff classification] —
+  Normative vs informative differences.
+* link:../match-options/index.adoc[Match options] — Configuring
+  `preserve_whitespace_elements`, `collapse_whitespace_elements`, and
+  `strip_whitespace_elements`.
+
+== History
+
+The cascade behaviour was reported in
+https://github.com/lutaml/canon/issues/137[issue #137]. The fix landed
+as a report-only re-alignment in PR #138.

--- a/docs/reference/environment-variables.adoc
+++ b/docs/reference/environment-variables.adoc
@@ -194,7 +194,9 @@ export CANON_JSON_FORMAT_PREPROCESSING=normalize
 |`CANON_SHOW_PRETTYPRINT_RECEIVED`
 |boolean
 |`false`
-|Show only the RECEIVED (actual) block in the fixture-ready pretty-printed section.  This is the most common fixture-update workflow: enable this option to get a copy-pasteable pretty-printed form of the generated output that can replace the old fixture heredoc.  Format-specific: `CANON_{FORMAT}_DIFF_SHOW_PRETTYPRINT_RECEIVED`
+|Show only the RECEIVED (actual) block in the fixture-ready pretty-printed section.  This is the most common fixture-update workflow: enable this option to get a copy-pasteable pretty-printed form of the generated output that can replace the old fixture heredoc.  Format-specific: `CANON_{FORMAT}_DIFF_SHOW_PRETTYPRINT_RECEIVED`.
+
+For HTML / HTML4 / HTML5 inputs, the pretty-printed output is XHTML-shaped: void elements are self-closed (`<br/>`, `<meta/>`), non-void elements are paired (`<a></a>`), and Nokogiri may add `xmlns="http://www.w3.org/1999/xhtml"` on `<html>` and an `xml:lang` mirror of `lang`.  This is a display-only serialisation chosen because libxml's `FORMAT` save flag (the only path that actually indents HTML5 input) requires the XHTML save mode -- `Nokogiri::HTML5#to_html` silently ignores its `indent:` keyword.  See lutaml/canon#133.
 |All formats (display only)
 
 |`CANON_COMPACT_SEMANTIC_REPORT`

--- a/lib/canon/comparison.rb
+++ b/lib/canon/comparison.rb
@@ -172,32 +172,13 @@ module Canon
       "#{code_label(diff1)} vs #{code_label(diff2)}"
     end
 
-    # Extract parse-time errors from a parsed-tree or Nokogiri-fragment
-    # node, regardless of which parser produced it.  Used by the
-    # comparators to plumb libxml's error list through to
-    # +ComparisonResult+ so the diff report can surface FATAL parse
-    # conditions that would otherwise silently drop content from the
-    # comparison tree.  See lutaml/canon#130.
+    # Extract parse-time errors from a parsed-tree or Nokogiri fragment.
+    # Delegates to NodeInspector for cross-backend type dispatch.
     #
-    # @param node [Object, nil] Parsed node (Canon::Xml::Node, Nokogiri
-    #   fragment/document, or nil)
+    # @param node [Object, nil] Parsed node
     # @return [Array<String>] Parse errors as strings (empty by default)
     def self.parse_errors_for(node)
-      return [] if node.nil?
-
-      # Canon::Xml::Node carries errors via the parse_errors accessor.
-      if node.respond_to?(:parse_errors)
-        errors = node.parse_errors
-        return Array(errors).map(&:to_s) if errors && !errors.empty?
-      end
-
-      # Nokogiri::XML::Document, Nokogiri::HTML5::DocumentFragment etc.
-      # expose errors natively.
-      if node.respond_to?(:errors)
-        return Array(node.errors).map(&:to_s)
-      end
-
-      []
+      NodeInspector.parse_errors(node)
     end
 
     class << self

--- a/lib/canon/comparison.rb
+++ b/lib/canon/comparison.rb
@@ -172,6 +172,34 @@ module Canon
       "#{code_label(diff1)} vs #{code_label(diff2)}"
     end
 
+    # Extract parse-time errors from a parsed-tree or Nokogiri-fragment
+    # node, regardless of which parser produced it.  Used by the
+    # comparators to plumb libxml's error list through to
+    # +ComparisonResult+ so the diff report can surface FATAL parse
+    # conditions that would otherwise silently drop content from the
+    # comparison tree.  See lutaml/canon#130.
+    #
+    # @param node [Object, nil] Parsed node (Canon::Xml::Node, Nokogiri
+    #   fragment/document, or nil)
+    # @return [Array<String>] Parse errors as strings (empty by default)
+    def self.parse_errors_for(node)
+      return [] if node.nil?
+
+      # Canon::Xml::Node carries errors via the parse_errors accessor.
+      if node.respond_to?(:parse_errors)
+        errors = node.parse_errors
+        return Array(errors).map(&:to_s) if errors && !errors.empty?
+      end
+
+      # Nokogiri::XML::Document, Nokogiri::HTML5::DocumentFragment etc.
+      # expose errors natively.
+      if node.respond_to?(:errors)
+        return Array(node.errors).map(&:to_s)
+      end
+
+      []
+    end
+
     class << self
       # Auto-detect format and compare two objects
       #

--- a/lib/canon/comparison/comparison_result.rb
+++ b/lib/canon/comparison/comparison_result.rb
@@ -6,7 +6,8 @@ module Canon
     # Provides methods to query equivalence based on normative diffs
     class ComparisonResult
       attr_reader :differences, :preprocessed_strings, :format, :html_version,
-                  :match_options, :algorithm, :original_strings
+                  :match_options, :algorithm, :original_strings,
+                  :parse_errors_expected, :parse_errors_received
 
       # @param differences [Array<DiffNode>] Array of difference nodes
       # @param preprocessed_strings [Array<String, String>] Pre-processed content for display
@@ -15,8 +16,11 @@ module Canon
       # @param match_options [Hash, nil] Resolved match options used for comparison
       # @param algorithm [Symbol] Diff algorithm used (:dom or :semantic)
       # @param original_strings [Array<String, String>, nil] Original unprocessed content for line diff
+      # @param parse_errors_expected [Array<String>, nil] Parser errors from the expected side
+      # @param parse_errors_received [Array<String>, nil] Parser errors from the received side
       def initialize(differences:, preprocessed_strings:, format:,
-html_version: nil, match_options: nil, algorithm: :dom, original_strings: nil)
+html_version: nil, match_options: nil, algorithm: :dom, original_strings: nil,
+parse_errors_expected: nil, parse_errors_received: nil)
         @differences = differences
         @preprocessed_strings = preprocessed_strings
         @original_strings = original_strings || preprocessed_strings
@@ -24,6 +28,16 @@ html_version: nil, match_options: nil, algorithm: :dom, original_strings: nil)
         @html_version = html_version
         @match_options = match_options
         @algorithm = algorithm
+        @parse_errors_expected = Array(parse_errors_expected)
+        @parse_errors_received = Array(parse_errors_received)
+      end
+
+      # Whether either side reported parse errors.  Used by the diff
+      # formatter to decide whether to render the parse-error banner.
+      #
+      # @return [Boolean]
+      def parse_errors?
+        @parse_errors_expected.any? || @parse_errors_received.any?
       end
 
       # Check if documents are semantically equivalent (no normative diffs)

--- a/lib/canon/comparison/html_comparator.rb
+++ b/lib/canon/comparison/html_comparator.rb
@@ -151,6 +151,8 @@ module Canon
               html_version: detect_html_version_from_node(node1),
               match_options: match_opts_hash,
               algorithm: :dom,
+              parse_errors_expected: Comparison.parse_errors_for(node1),
+              parse_errors_received: Comparison.parse_errors_for(node2),
             )
           elsif result != Comparison::EQUIVALENT && !differences.empty?
             # Non-verbose mode: check equivalence
@@ -300,6 +302,8 @@ module Canon
               html_version: html_version,
               match_options: match_opts_hash.merge(strategy.metadata),
               algorithm: :semantic,
+              parse_errors_expected: Comparison.parse_errors_for(node1),
+              parse_errors_received: Comparison.parse_errors_for(node2),
             )
           else
             # Simple boolean result - equivalent if no normative differences

--- a/lib/canon/comparison/markup_comparator.rb
+++ b/lib/canon/comparison/markup_comparator.rb
@@ -473,7 +473,7 @@ module Canon
             :text_content
           elsif node.respond_to?(:processing_instruction?) && node.processing_instruction?
             :processing_instructions
-          elsif node.respond_to?(:element?) && node.element?
+          elsif node.is_a?(Nokogiri::XML::Element)
             :element_structure
           else
             :text_content

--- a/lib/canon/comparison/node_inspector.rb
+++ b/lib/canon/comparison/node_inspector.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Canon
+  module Comparison
+    # Single source of truth for cross-backend node type operations.
+    #
+    # The comparison pipeline handles nodes from two backends:
+    # * Canon::Xml::Node (+ RootNode, ElementNode, TextNode, etc.) —
+    #   custom DOM built by SAX builder and DataModel.
+    # * Nokogiri::XML::Node (+ subclasses) — native Nokogiri nodes used
+    #   by the HTML comparator and some legacy paths.
+    #
+    # Every method here dispatches on type via +case/when+ (+is_a?+).
+    # No +respond_to?+ — the types are known at every call site.
+    module NodeInspector
+      CANON_TEXT_TYPE = :text
+      NOKOGIRI_TEXT_TYPE = defined?(Nokogiri::XML::Node::TEXT_NODE) ? Nokogiri::XML::Node::TEXT_NODE : 3
+
+      # True when +node+ is a text node (whitespace, content, etc.).
+      def self.text_node?(node)
+        case node
+        when Canon::Xml::Node
+          node.node_type == CANON_TEXT_TYPE
+        when Nokogiri::XML::Node
+          node.node_type == NOKOGIRI_TEXT_TYPE
+        else
+          false
+        end
+      end
+
+      # Extract the text content of +node+ as a String.
+      def self.text_content(node)
+        case node
+        when Canon::Xml::Node
+          node.value.to_s
+        when Nokogiri::XML::Node
+          node.content.to_s
+        else
+          node.to_s
+        end
+      end
+
+      # True when +node+ is a text node whose content is whitespace-only.
+      # Empty-string text nodes return false — those represent genuine
+      # empty-vs-content asymmetry, not pretty-print indentation.
+      def self.whitespace_only_text?(node)
+        return false unless text_node?(node)
+
+        text = text_content(node)
+        !text.empty? && text.strip.empty?
+      end
+
+      # Extract parse-time errors carried on a node or its owning document.
+      # Returns an Array of Strings.
+      def self.parse_errors(node)
+        case node
+        when nil
+          []
+        when Canon::Xml::Node
+          errors = node.parse_errors
+          Array(errors).map(&:to_s)
+        when Nokogiri::XML::Document, Nokogiri::HTML5::Document
+          Array(node.errors).map(&:to_s)
+        else
+          []
+        end
+      end
+    end
+  end
+end

--- a/lib/canon/comparison/xml_comparator.rb
+++ b/lib/canon/comparison/xml_comparator.rb
@@ -698,6 +698,10 @@ differences)
             return build_text_diff_reason(text1, text2)
           end
 
+          if dimension == :whitespace_adjacency
+            return build_whitespace_adjacency_reason(node1, node2)
+          end
+
           # For attribute values differences, show the actual values
           if dimension == :attribute_values
             attrs1 = extract_attributes(node1)
@@ -835,6 +839,83 @@ differences)
           vis2 = visualize_whitespace(text2)
 
           "Text: \"#{vis1}\" vs \"#{vis2}\""
+        end
+
+        # Build a Reason line for a +:whitespace_adjacency+ diff (#137).
+        # Names which side carries the whitespace, the adjacency position
+        # relative to content neighbours, and surfaces the whitespace
+        # with visible markers.
+        def build_whitespace_adjacency_reason(node1, node2)
+          text1 = extract_text_from_node(node1)
+          text2 = extract_text_from_node(node2)
+
+          cc = XmlComparatorHelpers::ChildComparison
+          ws_on_first = cc.send(:whitespace_only_text_node?, node1) &&
+            !cc.send(:whitespace_only_text_node?, node2)
+          ws_on_second = cc.send(:whitespace_only_text_node?, node2) &&
+            !cc.send(:whitespace_only_text_node?, node1)
+
+          if ws_on_first
+            ws_text = text1
+            content_text = text2
+            present_side = "EXPECTED"
+            absent_side = "ACTUAL"
+            ws_node = node1
+          elsif ws_on_second
+            ws_text = text2
+            content_text = text1
+            present_side = "ACTUAL"
+            absent_side = "EXPECTED"
+            ws_node = node2
+          else
+            return build_text_diff_reason(text1, text2)
+          end
+
+          position = whitespace_adjacency_position(ws_node)
+          ws_vis = visualize_whitespace(ws_text)
+          content_vis = content_text ? visualize_whitespace(truncate_text(content_text)) : "(none)"
+
+          "Whitespace #{position} \"#{content_vis}\": " \
+            "present on #{present_side} (\"#{ws_vis}\"), absent on #{absent_side}"
+        end
+
+        # Determine the adjacency position of a whitespace-only text
+        # node relative to its parent's other (non-whitespace) children.
+        def whitespace_adjacency_position(ws_node)
+          return :isolated unless ws_node.respond_to?(:parent)
+
+          parent = ws_node.parent
+          return :isolated if parent.nil?
+          return :isolated unless parent.respond_to?(:children)
+
+          siblings = parent.children
+          idx = siblings.index(ws_node)
+          return :isolated unless idx
+
+          before = sibling_with_content?(siblings, idx, -1)
+          after = sibling_with_content?(siblings, idx, 1)
+
+          if before && after then :surrounding
+          elsif before then :following
+          elsif after then :preceding
+          else :isolated
+          end
+        end
+
+        # Walk siblings outward from +idx+ in +direction+, skipping
+        # whitespace-only text nodes.  Returns true if any non-whitespace
+        # sibling exists in that direction.
+        def sibling_with_content?(siblings, idx, direction)
+          i = idx + direction
+          while i >= 0 && i < siblings.length
+            s = siblings[i]
+            text_only = s.respond_to?(:text?) && s.text? &&
+              s.respond_to?(:content) && s.content.to_s.strip.empty?
+            return true unless text_only
+
+            i += direction
+          end
+          false
         end
 
         # Check if text is only whitespace

--- a/lib/canon/comparison/xml_comparator.rb
+++ b/lib/canon/comparison/xml_comparator.rb
@@ -287,6 +287,8 @@ module Canon
           )
         end
 
+        public
+
         # Main comparison dispatcher
         def compare_nodes(n1, n2, opts, child_opts, diff_children, differences)
           # FAST PATH: Object identity - same object is always equivalent
@@ -377,7 +379,6 @@ module Canon
         end
 
         # Public comparison methods - exposed for XmlNodeComparison module
-        public
 
         # Compare two element nodes
         def compare_element_nodes(n1, n2, opts, child_opts, diff_children,
@@ -721,7 +722,8 @@ differences)
           elsif dimension == :element_structure &&
               diff1 == Canon::Comparison::UNEQUAL_ELEMENTS &&
               diff2 == Canon::Comparison::UNEQUAL_ELEMENTS &&
-              node1.respond_to?(:name) && node2.respond_to?(:name) &&
+              (node1.is_a?(Canon::Xml::Node) || node1.is_a?(Nokogiri::XML::Node)) &&
+              (node2.is_a?(Canon::Xml::Node) || node2.is_a?(Nokogiri::XML::Node)) &&
               node1.name && node2.name && node1.name != node2.name
             # Most common case: differing element names.  Surface the
             # actual names rather than a generic "elements differ".
@@ -849,11 +851,11 @@ differences)
           text1 = extract_text_from_node(node1)
           text2 = extract_text_from_node(node2)
 
-          cc = XmlComparatorHelpers::ChildComparison
-          ws_on_first = cc.send(:whitespace_only_text_node?, node1) &&
-            !cc.send(:whitespace_only_text_node?, node2)
-          ws_on_second = cc.send(:whitespace_only_text_node?, node2) &&
-            !cc.send(:whitespace_only_text_node?, node1)
+          ni = NodeInspector
+          ws_on_first = ni.whitespace_only_text?(node1) &&
+            !ni.whitespace_only_text?(node2)
+          ws_on_second = ni.whitespace_only_text?(node2) &&
+            !ni.whitespace_only_text?(node1)
 
           if ws_on_first
             ws_text = text1
@@ -879,14 +881,12 @@ differences)
             "present on #{present_side} (\"#{ws_vis}\"), absent on #{absent_side}"
         end
 
-        # Determine the adjacency position of a whitespace-only text
-        # node relative to its parent's other (non-whitespace) children.
         def whitespace_adjacency_position(ws_node)
-          return :isolated unless ws_node.respond_to?(:parent)
+          return :isolated unless ws_node.is_a?(Canon::Xml::Node) ||
+            ws_node.is_a?(Nokogiri::XML::Node)
 
           parent = ws_node.parent
           return :isolated if parent.nil?
-          return :isolated unless parent.respond_to?(:children)
 
           siblings = parent.children
           idx = siblings.index(ws_node)
@@ -902,16 +902,13 @@ differences)
           end
         end
 
-        # Walk siblings outward from +idx+ in +direction+, skipping
-        # whitespace-only text nodes.  Returns true if any non-whitespace
-        # sibling exists in that direction.
         def sibling_with_content?(siblings, idx, direction)
           i = idx + direction
           while i >= 0 && i < siblings.length
             s = siblings[i]
-            text_only = s.respond_to?(:text?) && s.text? &&
-              s.respond_to?(:content) && s.content.to_s.strip.empty?
-            return true unless text_only
+            is_ws_text = NodeInspector.text_node?(s) &&
+              NodeInspector.text_content(s).strip.empty?
+            return true unless is_ws_text
 
             i += direction
           end

--- a/lib/canon/comparison/xml_comparator.rb
+++ b/lib/canon/comparison/xml_comparator.rb
@@ -160,6 +160,8 @@ module Canon
               format: :xml,
               match_options: match_opts_hash,
               algorithm: :dom,
+              parse_errors_expected: Comparison.parse_errors_for(node1),
+              parse_errors_received: Comparison.parse_errors_for(node2),
             )
           elsif result != Comparison::EQUIVALENT && !differences.empty?
             # Non-verbose mode: check equivalence
@@ -222,6 +224,8 @@ module Canon
               format: :xml,
               match_options: match_opts_hash.merge(strategy.metadata),
               algorithm: :semantic,
+              parse_errors_expected: Comparison.parse_errors_for(node1),
+              parse_errors_received: Comparison.parse_errors_for(node2),
             )
           else
             # Simple boolean result - equivalent if no normative differences

--- a/lib/canon/comparison/xml_comparator/child_comparison.rb
+++ b/lib/canon/comparison/xml_comparator/child_comparison.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../node_inspector"
+
 module Canon
   module Comparison
     module XmlComparatorHelpers
@@ -27,7 +29,7 @@ module Canon
           # @param differences [Array] Array to collect differences
           # @return [Integer] Comparison result code
           def compare(node1, node2, comparator, opts, child_opts,
-diff_children, differences)
+                      diff_children, differences)
             # FAST PATH: Object identity - same object means equivalent children
             return Comparison::EQUIVALENT if node1.equal?(node2)
 
@@ -40,8 +42,8 @@ diff_children, differences)
             opts1 = XmlNodeComparison.opts_for_side(opts, :expected)
             opts2 = XmlNodeComparison.opts_for_side(opts, :received)
 
-            children1 = comparator.send(:filter_children, node1.children, opts1)
-            children2 = comparator.send(:filter_children, node2.children, opts2)
+            children1 = comparator.filter_children(node1.children, opts1)
+            children2 = comparator.filter_children(node2.children, opts2)
 
             # Quick check: if both have no children, they're equivalent
             return Comparison::EQUIVALENT if children1.empty? && children2.empty?
@@ -97,9 +99,9 @@ diff_children, differences)
 
             # If no matches and children exist, they're all different
             if matches.empty? && (!children1.empty? || !children2.empty?)
-              comparator.send(:add_difference, parent_node, parent_node,
-                              Comparison::MISSING_NODE, Comparison::MISSING_NODE,
-                              :text_content, opts, differences)
+              comparator.add_difference(parent_node, parent_node,
+                                        Comparison::MISSING_NODE, Comparison::MISSING_NODE,
+                                        :text_content, opts, differences)
               return Comparison::UNEQUAL_ELEMENTS
             end
 
@@ -122,30 +124,30 @@ diff_children, differences)
 
                   # Only create DiffNode if element_position is not :ignore
                   if position_behavior != :ignore
-                    comparator.send(:add_difference, match.elem1, match.elem2,
-                                    "position #{match.pos1}", "position #{match.pos2}",
-                                    :element_position, opts, differences)
+                    comparator.add_difference(match.elem1, match.elem2,
+                                              "position #{match.pos1}", "position #{match.pos2}",
+                                              :element_position, opts, differences)
                     all_equivalent = false if position_behavior == :strict
                   end
                 end
 
                 # Compare the matched elements for content/attribute differences
-                result = comparator.send(:compare_nodes, match.elem1, match.elem2,
-                                         child_opts, child_opts, diff_children, differences)
+                result = comparator.compare_nodes(match.elem1, match.elem2,
+                                                  child_opts, child_opts, diff_children, differences)
                 all_equivalent = false unless result == Comparison::EQUIVALENT
 
               when :deleted
                 # Element present in first tree but not second
-                comparator.send(:add_difference, match.elem1, nil,
-                                Comparison::MISSING_NODE, Comparison::MISSING_NODE,
-                                :element_structure, opts, differences)
+                comparator.add_difference(match.elem1, nil,
+                                          Comparison::MISSING_NODE, Comparison::MISSING_NODE,
+                                          :element_structure, opts, differences)
                 all_equivalent = false
 
               when :inserted
                 # Element present in second tree but not first
-                comparator.send(:add_difference, nil, match.elem2,
-                                Comparison::MISSING_NODE, Comparison::MISSING_NODE,
-                                :element_structure, opts, differences)
+                comparator.add_difference(nil, match.elem2,
+                                          Comparison::MISSING_NODE, Comparison::MISSING_NODE,
+                                          :element_structure, opts, differences)
                 all_equivalent = false
               end
             end
@@ -190,24 +192,23 @@ diff_children, differences)
 
               if mismatched_children.empty?
                 unless ws_asymmetric
-                  comparator.send(:add_difference, parent_node, parent_node,
-                                  Comparison::MISSING_NODE, Comparison::MISSING_NODE,
-                                  dimension, opts, differences)
+                  comparator.add_difference(parent_node, parent_node,
+                                            Comparison::MISSING_NODE, Comparison::MISSING_NODE,
+                                            dimension, opts, differences)
                 end
               else
                 mismatched_children.each do |child|
-                  child_dim = comparator.send(:determine_node_dimension,
-                                              child)
-                  if children1.length > children2.length # rubocop:disable Metrics/BlockNesting
-                    comparator.send(:add_difference, child, nil,
-                                    Comparison::MISSING_NODE,
-                                    Comparison::MISSING_NODE,
-                                    child_dim, opts, differences)
+                  child_dim = comparator.determine_node_dimension(child)
+                  if children1.length > children2.length
+                    comparator.add_difference(child, nil,
+                                              Comparison::MISSING_NODE,
+                                              Comparison::MISSING_NODE,
+                                              child_dim, opts, differences)
                   else
-                    comparator.send(:add_difference, nil, child,
-                                    Comparison::MISSING_NODE,
-                                    Comparison::MISSING_NODE,
-                                    child_dim, opts, differences)
+                    comparator.add_difference(nil, child,
+                                              Comparison::MISSING_NODE,
+                                              Comparison::MISSING_NODE,
+                                              child_dim, opts, differences)
                   end
                 end
               end
@@ -245,30 +246,30 @@ diff_children, differences)
                 next
               end
 
-              ws1 = whitespace_only_text_node?(c1)
-              ws2 = whitespace_only_text_node?(c2)
+              ws1 = NodeInspector.whitespace_only_text?(c1)
+              ws2 = NodeInspector.whitespace_only_text?(c2)
 
               if ws1 && !ws2
-                comparator.send(:add_difference, c1, c2,
-                                Comparison::UNEQUAL_TEXT_CONTENTS,
-                                Comparison::UNEQUAL_TEXT_CONTENTS,
-                                :whitespace_adjacency, opts, differences)
+                comparator.add_difference(c1, c2,
+                                          Comparison::UNEQUAL_TEXT_CONTENTS,
+                                          Comparison::UNEQUAL_TEXT_CONTENTS,
+                                          :whitespace_adjacency, opts, differences)
                 result = Comparison::UNEQUAL_TEXT_CONTENTS
                 i += 1
                 next
               elsif ws2 && !ws1
-                comparator.send(:add_difference, c1, c2,
-                                Comparison::UNEQUAL_TEXT_CONTENTS,
-                                Comparison::UNEQUAL_TEXT_CONTENTS,
-                                :whitespace_adjacency, opts, differences)
+                comparator.add_difference(c1, c2,
+                                          Comparison::UNEQUAL_TEXT_CONTENTS,
+                                          Comparison::UNEQUAL_TEXT_CONTENTS,
+                                          :whitespace_adjacency, opts, differences)
                 result = Comparison::UNEQUAL_TEXT_CONTENTS
                 j += 1
                 next
               end
 
-              child_result = comparator.send(:compare_nodes, c1, c2,
-                                             child_opts, child_opts,
-                                             diff_children, differences)
+              child_result = comparator.compare_nodes(c1, c2,
+                                                      child_opts, child_opts,
+                                                      diff_children, differences)
               result = child_result unless child_result == Comparison::EQUIVALENT
               i += 1
               j += 1
@@ -280,53 +281,9 @@ diff_children, differences)
           # True when the length difference between the two child arrays
           # is fully explained by asymmetric whitespace-only text nodes.
           def asymmetric_whitespace_explains_length_diff?(children1, children2)
-            non_ws1 = children1.reject { |c| whitespace_only_text_node?(c) }
-            non_ws2 = children2.reject { |c| whitespace_only_text_node?(c) }
+            non_ws1 = children1.reject { |c| NodeInspector.whitespace_only_text?(c) }
+            non_ws2 = children2.reject { |c| NodeInspector.whitespace_only_text?(c) }
             non_ws1.length == non_ws2.length
-          end
-
-          # True if +node+ is a text node whose content is whitespace-only.
-          # Empty-string text nodes are not treated as whitespace-only for
-          # re-alignment purposes — those represent a genuine
-          # empty-vs-content asymmetry, not a pretty-print indentation
-          # artefact.
-          def whitespace_only_text_node?(node)
-            return false if node.nil?
-            return false unless node_is_text?(node)
-
-            text = node_text_content(node).to_s
-            return false if text.empty?
-
-            text.strip.empty?
-          end
-
-          # Backend-agnostic text-node check.  Handles Canon::Xml::Node
-          # (node_type is Symbol), Nokogiri::XML::Node (node_type is
-          # Integer), and any node exposing +:text?+ without +:element?+.
-          def node_is_text?(node)
-            if node.respond_to?(:node_type) && node.node_type.is_a?(Symbol)
-              return node.node_type == :text
-            end
-
-            if node.respond_to?(:node_type) && node.node_type.is_a?(Integer)
-              if defined?(Nokogiri::XML::Node::TEXT_NODE)
-                return node.node_type == Nokogiri::XML::Node::TEXT_NODE
-              end
-
-              return node.node_type == 3
-            end
-
-            node.respond_to?(:text?) && node.text? &&
-              !node.respond_to?(:element?)
-          end
-
-          # Backend-agnostic text-content reader.
-          def node_text_content(node)
-            return node.value.to_s if node.respond_to?(:value) && !node.respond_to?(:element?)
-            return node.content.to_s if node.respond_to?(:content)
-            return node.text.to_s if node.respond_to?(:text)
-
-            node.to_s
           end
 
           # Determine dimension for length mismatch
@@ -338,22 +295,17 @@ diff_children, differences)
             (0...max_len).each do |i|
               if i >= children1.length
                 # Extra child in children2
-                dimension = comparator.send(:determine_node_dimension,
-                                            children2[i])
+                dimension = comparator.determine_node_dimension(children2[i])
                 break
               elsif i >= children2.length
                 # Extra child in children1
-                dimension = comparator.send(:determine_node_dimension,
-                                            children1[i])
+                dimension = comparator.determine_node_dimension(children1[i])
                 break
-              elsif !comparator.send(:same_node_type?, children1[i],
-                                     children2[i])
+              elsif !comparator.same_node_type?(children1[i], children2[i])
                 # Different node types at same position
                 # Check both nodes - if either is a comment, use :comments dimension
-                dim1 = comparator.send(:determine_node_dimension,
-                                       children1[i])
-                dim2 = comparator.send(:determine_node_dimension,
-                                       children2[i])
+                dim1 = comparator.determine_node_dimension(children1[i])
+                dim2 = comparator.determine_node_dimension(children2[i])
                 dimension = [dim1, dim2].include?(:comments) ? :comments : dim1
                 break
               end
@@ -375,7 +327,7 @@ diff_children, differences)
             end
 
             smaller_set_names = smaller_set.filter_map do |c|
-              next nil unless c.respond_to?(:name)
+              next nil unless c.is_a?(Canon::Xml::Node) || c.is_a?(Nokogiri::XML::Node)
               # Exclude generic node-type names (e.g. "#text") that are
               # shared by all text nodes and cannot be used for matching.
               next nil if c.name.start_with?("#")
@@ -390,7 +342,8 @@ diff_children, differences)
                 # If the smaller set has no child at this position,
                 # consider it a mismatch
                 mismatch_children << larger_set[i]
-              elsif larger_set[i].respond_to?(:name) &&
+              elsif (larger_set[i].is_a?(Canon::Xml::Node) ||
+                     larger_set[i].is_a?(Nokogiri::XML::Node)) &&
                   !larger_set[i].name.start_with?("#") &&
                   !smaller_set_names.include?(larger_set[i].name)
                 # If the name of the node is not found in the smaller set,

--- a/lib/canon/comparison/xml_comparator/child_comparison.rb
+++ b/lib/canon/comparison/xml_comparator/child_comparison.rb
@@ -153,9 +153,16 @@ diff_children, differences)
             all_equivalent ? Comparison::EQUIVALENT : Comparison::UNEQUAL_ELEMENTS
           end
 
-          # Use simple positional comparison for children
+          # Use simple positional comparison for children, with
+          # whitespace-asymmetry-aware re-alignment.  When positional
+          # +zip()+ would pair a whitespace-only text node on one side
+          # against a content node on the other, treat the whitespace
+          # node as a single-side gap: emit one +:whitespace_adjacency+
+          # diff anchored at the whitespace node and advance only the
+          # cursor carrying the whitespace, so the next iteration aligns
+          # content against content.  See lutaml/canon#137.
           def use_positional_comparison(
-            children1, children2, _parent_node, comparator,
+            children1, children2, parent_node, comparator,
             opts, child_opts, diff_children, differences
           )
             has_mismatch = false
@@ -163,26 +170,31 @@ diff_children, differences)
             # Length check
             unless children1.length == children2.length
               has_mismatch = true
-              dimension = determine_dimension_for_mismatch(
-                children1, children2, comparator
+
+              ws_asymmetric = asymmetric_whitespace_explains_length_diff?(
+                children1, children2
               )
 
-              mismatched_children, children1, children2 =
-                determine_mismatch_children(
+              if ws_asymmetric
+                dimension = nil
+                mismatched_children = []
+              else
+                dimension = determine_dimension_for_mismatch(
                   children1, children2, comparator
                 )
+                mismatched_children, children1, children2 =
+                  determine_mismatch_children(
+                    children1, children2, comparator
+                  )
+              end
 
               if mismatched_children.empty?
-                comparator.send(:add_difference, parent_node, parent_node,
-                                Comparison::MISSING_NODE, Comparison::MISSING_NODE,
-                                dimension, opts, differences)
+                unless ws_asymmetric
+                  comparator.send(:add_difference, parent_node, parent_node,
+                                  Comparison::MISSING_NODE, Comparison::MISSING_NODE,
+                                  dimension, opts, differences)
+                end
               else
-                # Per-child dimension based on the orphan's actual node
-                # type — an element orphan must be tagged
-                # :element_structure (not the prevailing positional
-                # default) so the diff formatter renders it as the
-                # element it is, rather than as +text ""+.  See
-                # lutaml/canon#125 follow-up.
                 mismatched_children.each do |child|
                   child_dim = comparator.send(:determine_node_dimension,
                                               child)
@@ -199,25 +211,122 @@ diff_children, differences)
                   end
                 end
               end
-              # Continue comparing children to find deeper differences like attribute values
-              # Use zip to compare up to the shorter length
             end
 
-            # Compare children pairwise by position
             result = has_mismatch ? Comparison::UNEQUAL_ELEMENTS : Comparison::EQUIVALENT
-            children1.zip(children2).each do |child1, child2|
-              # Skip if one is nil (due to different lengths)
-              next if child1.nil? || child2.nil?
+            walk_result = walk_children_with_realignment(
+              children1, children2, comparator,
+              child_opts, diff_children, opts, differences
+            )
+            result = walk_result unless walk_result == Comparison::EQUIVALENT
+            result
+          end
 
-              child_result = comparator.send(:compare_nodes, child1, child2,
-                                             child_opts, child_opts, diff_children, differences)
+          # Two-cursor walk over paired children that re-aligns past
+          # asymmetric whitespace-only text nodes.  Returns the worst
+          # child result encountered.
+          def walk_children_with_realignment(
+            children1, children2, comparator,
+            child_opts, diff_children, opts, differences
+          )
+            result = Comparison::EQUIVALENT
+            i = 0
+            j = 0
 
-              unless child_result == Comparison::EQUIVALENT
-                result = child_result
+            while i < children1.length || j < children2.length
+              c1 = children1[i]
+              c2 = children2[j]
+
+              if c1.nil?
+                j += 1
+                next
+              elsif c2.nil?
+                i += 1
+                next
               end
+
+              ws1 = whitespace_only_text_node?(c1)
+              ws2 = whitespace_only_text_node?(c2)
+
+              if ws1 && !ws2
+                comparator.send(:add_difference, c1, c2,
+                                Comparison::UNEQUAL_TEXT_CONTENTS,
+                                Comparison::UNEQUAL_TEXT_CONTENTS,
+                                :whitespace_adjacency, opts, differences)
+                result = Comparison::UNEQUAL_TEXT_CONTENTS
+                i += 1
+                next
+              elsif ws2 && !ws1
+                comparator.send(:add_difference, c1, c2,
+                                Comparison::UNEQUAL_TEXT_CONTENTS,
+                                Comparison::UNEQUAL_TEXT_CONTENTS,
+                                :whitespace_adjacency, opts, differences)
+                result = Comparison::UNEQUAL_TEXT_CONTENTS
+                j += 1
+                next
+              end
+
+              child_result = comparator.send(:compare_nodes, c1, c2,
+                                             child_opts, child_opts,
+                                             diff_children, differences)
+              result = child_result unless child_result == Comparison::EQUIVALENT
+              i += 1
+              j += 1
             end
 
             result
+          end
+
+          # True when the length difference between the two child arrays
+          # is fully explained by asymmetric whitespace-only text nodes.
+          def asymmetric_whitespace_explains_length_diff?(children1, children2)
+            non_ws1 = children1.reject { |c| whitespace_only_text_node?(c) }
+            non_ws2 = children2.reject { |c| whitespace_only_text_node?(c) }
+            non_ws1.length == non_ws2.length
+          end
+
+          # True if +node+ is a text node whose content is whitespace-only.
+          # Empty-string text nodes are not treated as whitespace-only for
+          # re-alignment purposes — those represent a genuine
+          # empty-vs-content asymmetry, not a pretty-print indentation
+          # artefact.
+          def whitespace_only_text_node?(node)
+            return false if node.nil?
+            return false unless node_is_text?(node)
+
+            text = node_text_content(node).to_s
+            return false if text.empty?
+
+            text.strip.empty?
+          end
+
+          # Backend-agnostic text-node check.  Handles Canon::Xml::Node
+          # (node_type is Symbol), Nokogiri::XML::Node (node_type is
+          # Integer), and any node exposing +:text?+ without +:element?+.
+          def node_is_text?(node)
+            if node.respond_to?(:node_type) && node.node_type.is_a?(Symbol)
+              return node.node_type == :text
+            end
+
+            if node.respond_to?(:node_type) && node.node_type.is_a?(Integer)
+              if defined?(Nokogiri::XML::Node::TEXT_NODE)
+                return node.node_type == Nokogiri::XML::Node::TEXT_NODE
+              end
+
+              return node.node_type == 3
+            end
+
+            node.respond_to?(:text?) && node.text? &&
+              !node.respond_to?(:element?)
+          end
+
+          # Backend-agnostic text-content reader.
+          def node_text_content(node)
+            return node.value.to_s if node.respond_to?(:value) && !node.respond_to?(:element?)
+            return node.content.to_s if node.respond_to?(:content)
+            return node.text.to_s if node.respond_to?(:text)
+
+            node.to_s
           end
 
           # Determine dimension for length mismatch

--- a/lib/canon/comparison/xml_comparator/diff_node_builder.rb
+++ b/lib/canon/comparison/xml_comparator/diff_node_builder.rb
@@ -4,6 +4,7 @@ require "set"
 require_relative "../../diff/diff_node"
 require_relative "../../diff/path_builder"
 require_relative "../../diff/node_serializer"
+require_relative "../node_inspector"
 
 module Canon
   module Comparison
@@ -52,7 +53,7 @@ module Canon
         # For deleted/inserted nodes, include namespace information if available
         if dimension == :text_content && (node1.nil? || node2.nil?)
           node = node1 || node2
-          if node.respond_to?(:name) && node.respond_to?(:namespace_uri)
+          if node.is_a?(Canon::Xml::Node) || node.is_a?(Nokogiri::XML::Node)
             ns = node.namespace_uri
             ns_info = if ns.nil? || ns.empty?
                         ""
@@ -91,7 +92,8 @@ module Canon
         elsif dimension == :element_structure &&
             diff1 == Canon::Comparison::UNEQUAL_ELEMENTS &&
             diff2 == Canon::Comparison::UNEQUAL_ELEMENTS &&
-            node1.respond_to?(:name) && node2.respond_to?(:name) &&
+            (node1.is_a?(Canon::Xml::Node) || node1.is_a?(Nokogiri::XML::Node)) &&
+            (node2.is_a?(Canon::Xml::Node) || node2.is_a?(Nokogiri::XML::Node)) &&
             node1.name && node2.name && node1.name != node2.name
           "different element name (<#{node1.name}> vs <#{node2.name}>)"
         else
@@ -183,26 +185,18 @@ module Canon
       def self.extract_text_content(node)
         return nil if node.nil?
 
-        # For Canon::Xml::Nodes::TextNode
-        return node.value if node.respond_to?(:value) && node.is_a?(Canon::Xml::Nodes::TextNode)
-
-        # For XML/HTML nodes with text_content method
-        return node.text_content if node.respond_to?(:text_content)
-
-        # For nodes with text method
-        return node.text if node.respond_to?(:text)
-
-        # For nodes with content method (Moxml::Text)
-        return node.content if node.respond_to?(:content)
-
-        # For nodes with value method (other types)
-        return node.value if node.respond_to?(:value)
-
-        # For simple text nodes or strings
-        return node.to_s if node.is_a?(String)
-
-        # For other node types, try to_s
-        node.to_s
+        case node
+        when Canon::Xml::Nodes::TextNode
+          node.value
+        when Canon::Xml::Node
+          node.text_content
+        when Nokogiri::XML::Node
+          node.content.to_s
+        when String
+          node
+        else
+          node.to_s
+        end
       rescue StandardError
         nil
       end

--- a/lib/canon/diff/diff_classifier.rb
+++ b/lib/canon/diff/diff_classifier.rb
@@ -73,6 +73,16 @@ module Canon
           return diff_node
         end
 
+        # :whitespace_adjacency is a report-only re-label of an
+        # asymmetric whitespace mismatch emitted by ChildComparison's
+        # two-cursor walk.  Equivalence behaviour is unchanged — the
+        # underlying mismatch is normative regardless of match options.
+        if diff_node.dimension == :whitespace_adjacency
+          diff_node.formatting = false
+          diff_node.normative = true
+          return diff_node
+        end
+
         # THIRD: Determine if this dimension is normative based on CompareProfile
         # This respects the policy settings (strict/normalize/ignore)
         is_normative = profile.normative_dimension?(diff_node.dimension)

--- a/lib/canon/diff_formatter.rb
+++ b/lib/canon/diff_formatter.rb
@@ -366,8 +366,13 @@ module Canon
     # @param actual [Object] Actual value
     # @return [String] Formatted diff output
     def format_comparison_result(comparison_result, expected, actual)
-      # Detect format from expected content
-      format = Canon::Comparison::FormatDetector.detect(expected)
+      # Prefer the matcher-supplied format (e.g. :html4 from
+      # be_html4_equivalent_to). Auto-detection from the expected string
+      # cannot distinguish HTML from XML for fragments like
+      # `<div class="x"></div>` and would mis-route HTML fixtures
+      # through the XML pretty-printer (issue #135).
+      format = (comparison_result.respond_to?(:format) && comparison_result.format) ||
+        Canon::Comparison::FormatDetector.detect(expected)
 
       formatter_options = {
         use_color: @use_color,
@@ -909,6 +914,7 @@ module Canon
         collapse_whitespace_elements: @collapse_whitespace_elements,
         strip_whitespace_elements: @strip_whitespace_elements,
         sort_attributes: @pretty_printer_sort_attributes,
+        html_mode: %i[html html4 html5].include?(format),
       }
 
       printer_expected = Canon::PrettyPrinter::XmlNormalized.new(

--- a/lib/canon/diff_formatter.rb
+++ b/lib/canon/diff_formatter.rb
@@ -392,6 +392,18 @@ module Canon
         output << "" # Blank line for spacing
       end
 
+      # Parse-error banner.  When libxml flagged any errors during
+      # parsing, surface them at the top of the report so the user
+      # is not left chasing diffs that describe a partial tree.
+      # See lutaml/canon#130.
+      if comparison_result.is_a?(Canon::Comparison::ComparisonResult) &&
+          comparison_result.parse_errors?
+        output << format_parse_error_banner(
+          comparison_result.parse_errors_expected,
+          comparison_result.parse_errors_received,
+        )
+      end
+
       # 1. CANON VERBOSE tables (ONLY if CANON_VERBOSE=1)
       verbose_tables = DebugOutput.verbose_tables_only(
         comparison_result,
@@ -506,6 +518,53 @@ module Canon
     end
 
     private
+
+    # Render the parse-error banner that appears at the top of the
+    # diff report when libxml flagged any errors during parsing.
+    # Names the offending side(s) and warns that the diff below
+    # describes the parsed tree, not the input.  See lutaml/canon#130.
+    #
+    # @param errors_expected [Array<String>] Errors from the expected side
+    # @param errors_received [Array<String>] Errors from the received side
+    # @return [String] Multi-line banner
+    def format_parse_error_banner(errors_expected, errors_received)
+      lines = []
+      rule = "=" * 70
+      lines << colorize(rule, :yellow, :bold)
+      lines << colorize("  ⚠️  PARSE ERRORS", :yellow, :bold)
+      lines << colorize(rule, :yellow, :bold)
+
+      if errors_expected.any?
+        lines << colorize("  Expected side:", :yellow, :bold)
+        errors_expected.each do |err|
+          lines << "    #{colorize(err, :red)}"
+        end
+      end
+
+      if errors_received.any?
+        lines << colorize("  Received side:", :yellow, :bold)
+        errors_received.each do |err|
+          lines << "    #{colorize(err, :red)}"
+        end
+      end
+
+      lines << ""
+      lines << colorize(
+        "  ⚠️  The diff below describes the parsed tree, not the input.",
+        :yellow,
+      )
+      lines << colorize(
+        "      Content that the parser could not represent has been",
+        :yellow,
+      )
+      lines << colorize(
+        "      dropped and may appear as \"missing\" in the report.",
+        :yellow,
+      )
+      lines << colorize(rule, :yellow, :bold)
+      lines << ""
+      lines.join("\n")
+    end
 
     # Normalize content for display in diffs
     #

--- a/lib/canon/diff_formatter.rb
+++ b/lib/canon/diff_formatter.rb
@@ -371,7 +371,7 @@ module Canon
       # cannot distinguish HTML from XML for fragments like
       # `<div class="x"></div>` and would mis-route HTML fixtures
       # through the XML pretty-printer (issue #135).
-      format = (comparison_result.respond_to?(:format) && comparison_result.format) ||
+      format = (comparison_result.is_a?(Canon::Comparison::ComparisonResult) && comparison_result.format) ||
         Canon::Comparison::FormatDetector.detect(expected)
 
       formatter_options = {

--- a/lib/canon/diff_formatter.rb
+++ b/lib/canon/diff_formatter.rb
@@ -990,9 +990,13 @@ module Canon
 
       if %i[html html4 html5].include?(format)
         require "canon/pretty_printer/html"
+        # Fixture-ready mode actually indents (libxml FORMAT save flag
+        # via AS_XHTML).  The default mode is structurally faithful but
+        # does not indent on HTML5 input -- see lutaml/canon#133.
         printer = Canon::PrettyPrinter::Html.new(
           indent: @pretty_printer_indent,
           indent_type: indent_type_str,
+          fixture_ready: true,
         )
       elsif format == :xml
         require "canon/pretty_printer/xml"

--- a/lib/canon/diff_formatter/diff_detail_formatter/dimension_formatter.rb
+++ b/lib/canon/diff_formatter/diff_detail_formatter/dimension_formatter.rb
@@ -444,12 +444,14 @@ expand_difference: false)
         def self.present_is_element?(node)
           return false unless node
 
-          if node.respond_to?(:node_type) && node.node_type.is_a?(Symbol)
-            return node.node_type == :element
+          case node
+          when Canon::Xml::Node
+            node.node_type == :element
+          when Nokogiri::XML::Node
+            node.element?
+          else
+            false
           end
-          return true if node.respond_to?(:element?) && node.element?
-
-          false
         end
 
         # Render a one-sided text-content diff (one node nil, the other a
@@ -532,7 +534,7 @@ expand_difference: false)
             :green, use_color
           )
 
-          reason = if diff.respond_to?(:reason)
+          reason = if diff.is_a?(Canon::Diff::DiffNode)
                      diff.reason
                    else
                      diff.is_a?(Hash) ? diff[:reason] : nil

--- a/lib/canon/diff_formatter/diff_detail_formatter/dimension_formatter.rb
+++ b/lib/canon/diff_formatter/diff_detail_formatter/dimension_formatter.rb
@@ -34,6 +34,8 @@ expand_difference: false)
             format_attribute_order_details(diff, use_color)
           when :text_content
             format_text_content_details(diff, use_color, compact: compact)
+          when :whitespace_adjacency
+            format_whitespace_adjacency_details(diff, use_color)
           when :structural_whitespace
             format_structural_whitespace_details(diff, use_color)
           when :comments
@@ -505,6 +507,41 @@ expand_difference: false)
 
         # Format structural whitespace differences
         #
+        # Format a :whitespace_adjacency diff (#137).
+        #
+        # @param diff [DiffNode, Hash] Difference node
+        # @param use_color [Boolean] Whether to use colors
+        # @return [Array] Tuple of [detail1, detail2, changes]
+        def self.format_whitespace_adjacency_details(diff, use_color)
+          require_relative "color_helper"
+          require_relative "node_utils"
+          require_relative "text_utils"
+
+          node1 = extract_node1(diff)
+          node2 = extract_node2(diff)
+
+          text1 = NodeUtils.get_node_text(node1).to_s
+          text2 = NodeUtils.get_node_text(node2).to_s
+
+          detail1 = ColorHelper.colorize(
+            "\"#{TextUtils.visualize_whitespace(text1)}\"",
+            :red, use_color
+          )
+          detail2 = ColorHelper.colorize(
+            "\"#{TextUtils.visualize_whitespace(text2)}\"",
+            :green, use_color
+          )
+
+          reason = if diff.respond_to?(:reason)
+                     diff.reason
+                   else
+                     diff.is_a?(Hash) ? diff[:reason] : nil
+                   end
+          changes = reason.to_s
+
+          [detail1, detail2, changes]
+        end
+
         # @param diff [DiffNode, Hash] Difference node
         # @param use_color [Boolean] Whether to use colors
         # @return [Array] Tuple of [detail1, detail2, changes]

--- a/lib/canon/diff_formatter/diff_detail_formatter/node_utils.rb
+++ b/lib/canon/diff_formatter/diff_detail_formatter/node_utils.rb
@@ -337,9 +337,7 @@ module Canon
           when Canon::Xml::Nodes::ElementNode
             tag = node.name.to_s
             attrs = node.attribute_nodes.map do |attr|
-              attr_name  = attr.respond_to?(:name)  ? attr.name.to_s  : attr.to_s
-              attr_value = attr.respond_to?(:value) ? attr.value.to_s : ""
-              " #{attr_name}=\"#{CGI.escapeHTML(attr_value)}\""
+              " #{attr.name}=\"#{CGI.escapeHTML(attr.value.to_s)}\""
             end.join
             "<#{tag}#{attrs}>"
           when Nokogiri::XML::Element
@@ -363,12 +361,11 @@ module Canon
         def self.raw_text_value(node)
           return "" unless node
 
-          if node.respond_to?(:value) && !node.is_a?(Nokogiri::XML::Node)
+          case node
+          when Canon::Xml::Node
             node.value.to_s
-          elsif node.respond_to?(:content)
+          when Nokogiri::XML::Node
             node.content.to_s
-          elsif node.respond_to?(:text)
-            node.text.to_s
           else
             ""
           end

--- a/lib/canon/pretty_printer/html.rb
+++ b/lib/canon/pretty_printer/html.rb
@@ -2,10 +2,11 @@
 
 require "nokogiri"
 require "stringio"
+require_relative "html_void_elements"
 
 module Canon
   module PrettyPrinter
-    # Pretty printer for HTML with consistent indentation
+    # Pretty printer for HTML with consistent indentation.
     #
     # Two modes:
     #
@@ -22,10 +23,11 @@ module Canon
     #    (the +CANON_<FORMAT>_DIFF_SHOW_PRETTYPRINT_RECEIVED+ surface)
     #    so the user can read or paste the formatted output directly
     #    into a fixture heredoc.  Output is XHTML-shaped (void
-    #    elements self-closed, non-void paired) and prefixed with
-    #    +<?xml ...?>+; this is a display-only serialisation.
+    #    elements self-closed, non-void paired) via the +AS_XHTML+
+    #    save flag; the +NO_DECLARATION+ flag suppresses the
+    #    +<?xml ...?>+ prefix.
     #
-    # See lutaml/canon#133.
+    # See lutaml/canon#133, lutaml/canon#135.
     class Html
       def initialize(indent: 2, indent_type: "space", fixture_ready: false)
         @indent = indent.to_i
@@ -33,11 +35,9 @@ module Canon
         @fixture_ready = fixture_ready
       end
 
-      # Pretty print HTML with consistent indentation
       def format(html_string)
         return format_fixture_ready(html_string) if @fixture_ready
 
-        # Detect if this is XHTML or HTML
         if xhtml?(html_string)
           format_as_xhtml(html_string)
         else
@@ -48,28 +48,25 @@ module Canon
       private
 
       def xhtml?(html_string)
-        # Check for XHTML DOCTYPE or xmlns attribute
         html_string.include?("XHTML") ||
           html_string.include?('xmlns="http://www.w3.org/1999/xhtml"')
       end
 
       def format_as_xhtml(html_string)
-        # Parse as XML for XHTML
         doc = Nokogiri::XML(html_string, &:noblanks)
 
-        # Use Nokogiri's built-in pretty printing
-        if @indent_type == "tab"
-          doc.to_xml(indent: 1, indent_text: "\t", encoding: "UTF-8")
-        else
-          doc.to_xml(indent: @indent, encoding: "UTF-8")
-        end
+        out = if @indent_type == "tab"
+                doc.to_xml(indent: 1, indent_text: "\t", encoding: "UTF-8")
+              else
+                doc.to_xml(indent: @indent, encoding: "UTF-8")
+              end
+
+        expand_non_void_self_closing(out)
       end
 
       def format_as_html(html_string)
-        # Parse as HTML5
         doc = Nokogiri::HTML5(html_string)
 
-        # Use Nokogiri's built-in pretty printing
         if @indent_type == "tab"
           doc.to_html(indent: 1, indent_text: "\t", encoding: "UTF-8")
         else
@@ -82,10 +79,8 @@ module Canon
       # input shapes), then write through libxml's XML writer with
       # +FORMAT+ + +AS_XHTML+ + +NO_DECLARATION+.  +FORMAT+ inserts
       # indentation; +AS_XHTML+ produces well-shaped output (void
-      # elements self-closed, non-void paired) which is the format
-      # users want to paste into a fixture heredoc.  +NO_DECLARATION+
-      # suppresses the +<?xml ...?>+ prefix that libxml otherwise
-      # emits in XML-writer mode.
+      # elements self-closed, non-void paired); +NO_DECLARATION+
+      # suppresses the +<?xml ...?>+ prefix.
       def format_fixture_ready(html_string)
         doc = Nokogiri::HTML5(html_string)
         io = StringIO.new
@@ -103,6 +98,21 @@ module Canon
         Nokogiri::XML::Node::SaveOptions::FORMAT |
           Nokogiri::XML::Node::SaveOptions::AS_XHTML |
           Nokogiri::XML::Node::SaveOptions::NO_DECLARATION
+      end
+
+      # Rewrite +<tag …/>+ into +<tag …></tag>+ for every element name
+      # that is not an HTML5 void element. +<a/>+ is illegal HTML;
+      # void tags like +<br/>+ and +<img …/>+ pass through unchanged.
+      def expand_non_void_self_closing(html)
+        html.gsub(%r{<([A-Za-z][A-Za-z0-9:_-]*)((?:\s+[^<>"]*(?:"[^"]*"[^<>"]*)*)?)/>}) do
+          name = ::Regexp.last_match(1)
+          attrs = ::Regexp.last_match(2)
+          if HtmlVoidElements.void?(name)
+            "<#{name}#{attrs}/>"
+          else
+            "<#{name}#{attrs}></#{name}>"
+          end
+        end
       end
     end
   end

--- a/lib/canon/pretty_printer/html.rb
+++ b/lib/canon/pretty_printer/html.rb
@@ -1,18 +1,42 @@
 # frozen_string_literal: true
 
 require "nokogiri"
+require "stringio"
 
 module Canon
   module PrettyPrinter
     # Pretty printer for HTML with consistent indentation
+    #
+    # Two modes:
+    #
+    # 1. Default mode (+fixture_ready: false+): retains the existing
+    #    behaviour for callers that use the pretty-printer as a
+    #    structural normaliser (the canon round-trip tests, the
+    #    diff-pipeline +apply_pretty_print+ stage, etc).  These callers
+    #    do not require actual indentation; they require structural
+    #    equivalence to the input.
+    #
+    # 2. Fixture-ready mode (+fixture_ready: true+): emits
+    #    actually-indented XHTML-shaped output via libxml's +FORMAT+
+    #    save flag.  Used by +DiffFormatter#prettyprint_for_display+
+    #    (the +CANON_<FORMAT>_DIFF_SHOW_PRETTYPRINT_RECEIVED+ surface)
+    #    so the user can read or paste the formatted output directly
+    #    into a fixture heredoc.  Output is XHTML-shaped (void
+    #    elements self-closed, non-void paired) and prefixed with
+    #    +<?xml ...?>+; this is a display-only serialisation.
+    #
+    # See lutaml/canon#133.
     class Html
-      def initialize(indent: 2, indent_type: "space")
+      def initialize(indent: 2, indent_type: "space", fixture_ready: false)
         @indent = indent.to_i
         @indent_type = indent_type
+        @fixture_ready = fixture_ready
       end
 
       # Pretty print HTML with consistent indentation
       def format(html_string)
+        return format_fixture_ready(html_string) if @fixture_ready
+
         # Detect if this is XHTML or HTML
         if xhtml?(html_string)
           format_as_xhtml(html_string)
@@ -51,6 +75,34 @@ module Canon
         else
           doc.to_html(indent: @indent, encoding: "UTF-8")
         end
+      end
+
+      # Fixture-ready serialisation: parse with Nokogiri::HTML5 (so we
+      # get permissive recovery on real-world Word / XHTML5 / HTML5
+      # input shapes), then write through libxml's XML writer with
+      # +FORMAT+ + +AS_XHTML+ + +NO_DECLARATION+.  +FORMAT+ inserts
+      # indentation; +AS_XHTML+ produces well-shaped output (void
+      # elements self-closed, non-void paired) which is the format
+      # users want to paste into a fixture heredoc.  +NO_DECLARATION+
+      # suppresses the +<?xml ...?>+ prefix that libxml otherwise
+      # emits in XML-writer mode.
+      def format_fixture_ready(html_string)
+        doc = Nokogiri::HTML5(html_string)
+        io = StringIO.new
+        if @indent_type == "tab"
+          doc.write_to(io, save_with: fixture_ready_save_options,
+                           indent: 1, indent_text: "\t")
+        else
+          doc.write_to(io, save_with: fixture_ready_save_options,
+                           indent: @indent)
+        end
+        io.string
+      end
+
+      def fixture_ready_save_options
+        Nokogiri::XML::Node::SaveOptions::FORMAT |
+          Nokogiri::XML::Node::SaveOptions::AS_XHTML |
+          Nokogiri::XML::Node::SaveOptions::NO_DECLARATION
       end
     end
   end

--- a/lib/canon/pretty_printer/html_void_elements.rb
+++ b/lib/canon/pretty_printer/html_void_elements.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "set"
+
+module Canon
+  module PrettyPrinter
+    # The 14 HTML5 void elements — those whose start tag may stand alone
+    # (with no end tag) and which cannot have any content. Every other
+    # element with no children must be written as +<tag></tag>+ in HTML;
+    # writing +<a/>+ is illegal HTML and is parsed as +<a>+ (start tag only).
+    module HtmlVoidElements
+      VOID = Set.new(%w[area base br col embed hr img input link meta param
+                        source track wbr]).freeze
+
+      def self.void?(name)
+        VOID.include?(name.to_s.downcase)
+      end
+    end
+  end
+end

--- a/lib/canon/pretty_printer/xml_normalized.rb
+++ b/lib/canon/pretty_printer/xml_normalized.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "nokogiri"
+require_relative "html_void_elements"
 
 module Canon
   module PrettyPrinter
@@ -133,12 +134,14 @@ module Canon
                      collapse_whitespace_elements: [],
                      strip_whitespace_elements: [],
                      pretty_printed: false,
-                     sort_attributes: false)
+                     sort_attributes: false,
+                     html_mode: false)
         @indent = indent.to_i
         @indent_char = indent_type == "tab" ? "\t" : " "
         @vis_map = visualization_map || default_vis_map
         @pretty_printed = pretty_printed
         @sort_attributes = sort_attributes
+        @html_mode = html_mode
 
         @strict_ws  = Set.new((preserve_whitespace_elements || []).map(&:to_s))
         @norm_ws    = Set.new((collapse_whitespace_elements || []).map(&:to_s))
@@ -151,10 +154,10 @@ module Canon
       # @return [String] Serialized XML, one node per line, with content
       #   whitespace visualized at line boundaries
       def format(xml_string)
-        doc = Nokogiri::XML(xml_string)
+        doc = @html_mode ? Nokogiri::HTML5(xml_string) : Nokogiri::XML(xml_string)
         lines = []
 
-        if doc.version
+        if !@html_mode && doc.version
           enc = doc.encoding ? " encoding=\"#{doc.encoding}\"" : ""
           lines << "<?xml version=\"#{doc.version}\"#{enc}?>"
         end
@@ -198,6 +201,10 @@ module Canon
         children = node.children.reject { |c| c.text? && c.content.empty? }
 
         if children.empty?
+          if @html_mode && !HtmlVoidElements.void?(node.name)
+            return "#{ind(depth)}#{open_tag(node)}</#{node.name}>"
+          end
+
           return "#{ind(depth)}#{open_tag(node,
                                           self_close: true)}"
         end

--- a/lib/canon/xml/data_model.rb
+++ b/lib/canon/xml/data_model.rb
@@ -41,8 +41,7 @@ module Canon
         # list, downstream diffs describe the partial tree, not the
         # input.
         errors = Array(doc.errors).map(&:to_s)
-        result.parse_errors = errors if errors.any? &&
-          result.respond_to?(:parse_errors=)
+        result.parse_errors = errors if errors.any?
 
         result
       end

--- a/lib/canon/xml/data_model.rb
+++ b/lib/canon/xml/data_model.rb
@@ -31,7 +31,20 @@ module Canon
         check_for_relative_namespace_uris(doc)
 
         # Convert to XPath data model
-        build_from_nokogiri(doc, preserve_whitespace: preserve_whitespace)
+        result = build_from_nokogiri(doc,
+                                     preserve_whitespace: preserve_whitespace)
+
+        # Carry libxml's parse errors on the resulting tree so the diff
+        # report can surface them (see lutaml/canon#130).  libxml's
+        # FATAL conditions (e.g. duplicate attributes) silently drop
+        # content from the parse tree; without surfacing the error
+        # list, downstream diffs describe the partial tree, not the
+        # input.
+        errors = Array(doc.errors).map(&:to_s)
+        result.parse_errors = errors if errors.any? &&
+          result.respond_to?(:parse_errors=)
+
+        result
       end
 
       # Normalize XML string encoding to UTF-8

--- a/lib/canon/xml/node.rb
+++ b/lib/canon/xml/node.rb
@@ -32,7 +32,7 @@ module Canon
       #
       # @return [Array<String>] Parse errors as strings (empty by default)
       def parse_errors
-        instance_variable_defined?(:@parse_errors) ? @parse_errors : []
+        @parse_errors || []
       end
 
       def parse_errors=(value)

--- a/lib/canon/xml/node.rb
+++ b/lib/canon/xml/node.rb
@@ -24,6 +24,21 @@ module Canon
         @in_node_set = value
       end
 
+      # Parse-time errors carried alongside the node tree, captured at
+      # parse boundaries (Canon::Xml::DataModel.from_xml, etc.) so the
+      # diff report can surface libxml-level FATAL conditions that
+      # would otherwise be silently swallowed and produce misleading
+      # diffs against a partially-loaded tree.  See lutaml/canon#130.
+      #
+      # @return [Array<String>] Parse errors as strings (empty by default)
+      def parse_errors
+        instance_variable_defined?(:@parse_errors) ? @parse_errors : []
+      end
+
+      def parse_errors=(value)
+        @parse_errors = Array(value)
+      end
+
       # Return the text content of this node and all descendants.
       # ElementNode concatenates children's text_content; other nodes
       # (TextNode, CommentNode, etc.) return their value.

--- a/lib/canon/xml/sax_builder.rb
+++ b/lib/canon/xml/sax_builder.rb
@@ -93,6 +93,23 @@ strip_doctype: false)
         # Track in-scope namespaces at each level
         # Each entry is a hash of prefix => uri
         @namespace_stack = [build_initial_namespaces]
+        # Captured libxml errors during SAX parsing.  Surfaced on the
+        # resulting RootNode so the diff report can warn the user
+        # when a FATAL parse error has caused content loss
+        # (see lutaml/canon#130).
+        @parse_errors = []
+      end
+
+      # SAX callbacks for libxml errors and warnings.  Without these
+      # overrides the default handlers swallow the events; with them,
+      # libxml's "Attribute xml:lang redefined" and similar messages
+      # land in @parse_errors and ride through to ComparisonResult.
+      def error(string)
+        @parse_errors << string.to_s.strip
+      end
+
+      def warning(string)
+        @parse_errors << string.to_s.strip
       end
 
       # Called when an element starts
@@ -229,6 +246,7 @@ strip_doctype: false)
         # followed by PIs and comments outside the document element
         # (C14N requires this ordering)
         reorder_children(@root)
+        @root.parse_errors = @parse_errors if @parse_errors.any?
         @root
       end
 

--- a/spec/canon/comparison/diff_node_builder_spec.rb
+++ b/spec/canon/comparison/diff_node_builder_spec.rb
@@ -50,9 +50,8 @@ RSpec.describe Canon::Comparison::DiffNodeBuilder do
 
     describe ":text_content dimension" do
       it "shows truncated text when both have content" do
-        node1 = double("node",
-                       text_content: "This is some very long text content that exceeds the limit")
-        node2 = double("node", text_content: "This is some short content")
+        node1 = Canon::Xml::Nodes::TextNode.new(value: "This is some very long text content that exceeds the limit")
+        node2 = Canon::Xml::Nodes::TextNode.new(value: "This is some short content")
 
         reason = described_class.build_reason(
           node1, node2, 9, 9, :text_content
@@ -62,14 +61,14 @@ RSpec.describe Canon::Comparison::DiffNodeBuilder do
       end
 
       it "handles missing text gracefully" do
-        node1 = double("node", text_content: nil)
-        node2 = double("node", text_content: "present")
+        node1 = Canon::Xml::Nodes::TextNode.new(value: "")
+        node2 = Canon::Xml::Nodes::TextNode.new(value: "present")
 
         reason = described_class.build_reason(
           node1, node2, 9, 9, :text_content
         )
 
-        expect(reason).to eq("missing vs 'present'")
+        expect(reason).to eq("'' vs 'present'")
       end
     end
 

--- a/spec/canon/comparison/html_comparator_spec.rb
+++ b/spec/canon/comparison/html_comparator_spec.rb
@@ -437,15 +437,11 @@ RSpec.describe Canon::Comparison::HtmlComparator do
       end
     end
 
-    context "text_content one-sided diff rendering (issue #125)" do
-      # When two HTML fragments differ only in inter-sibling whitespace
-      # (e.g. a fixture with newlines between empty inline elements vs a
-      # generator that emits them adjacent), the resulting :text_content
-      # diffs carry a text node on one side and nil on the other.  The
-      # rendered output must show "(not present)" on the nil side and a
-      # brief, quoted text payload on the present side — not the entire
-      # ancestor element subtree (the regression this issue addresses).
-      it "renders missing whitespace text without dumping the ancestor subtree" do
+    context "one-sided whitespace asymmetry rendering (issues #125 + #137)" do
+      # When two HTML fragments differ only in inter-sibling whitespace,
+      # the asymmetry is re-classified as :whitespace_adjacency (#137,
+      # report-only) and rendered via format_whitespace_adjacency_details.
+      it "re-classifies whitespace asymmetry as :whitespace_adjacency without dumping ancestor subtree" do
         html1 = "<div id=\"A\"><a id=\"x\"></a>\n   <a id=\"y\"></a></div>"
         html2 = "<div id=\"A\"><a id=\"x\"></a><a id=\"y\"></a></div>"
 
@@ -453,32 +449,28 @@ RSpec.describe Canon::Comparison::HtmlComparator do
           html1, html2, format: :html5, verbose: true
         )
 
-        text_diffs = result.differences.grep(Canon::Diff::DiffNode).select do |d|
-          d.dimension == :text_content
+        ws_adj_diffs = result.differences.grep(Canon::Diff::DiffNode).select do |d|
+          d.dimension == :whitespace_adjacency
         end
-        expect(text_diffs).not_to be_empty
+        expect(ws_adj_diffs).not_to be_empty
 
         require "canon/diff_formatter/diff_detail_formatter/dimension_formatter"
         formatter =
           Canon::DiffFormatter::DiffDetailFormatterHelpers::DimensionFormatter
-        detail1, detail2, changes = formatter.format_text_content_details(
-          text_diffs.first, false
+        detail1, detail2, changes = formatter.format_whitespace_adjacency_details(
+          ws_adj_diffs.first, false
         )
 
-        # One side renders "(not present)", the other renders quoted text
-        # with the parent open-tag hint.
-        expect([detail1, detail2]).to include("(not present)")
-        expect(changes).to match(/Text (added|removed):/)
+        # No full-subtree dump in the rendered output (#125 invariant).
+        [detail1, detail2, changes].each do |part|
+          next if part.nil?
 
-        present = detail1 == "(not present)" ? detail2 : detail1
-        expect(present).to start_with("text \"")
-        expect(present).to include("in <div id=\"A\">")
+          expect(part).not_to include("</div>")
+          expect(part).not_to include("<a")
+        end
 
-        # Critically: no full-subtree dump.  The parent open-tag hint must
-        # not include a closing tag or any child elements.
-        expect(present).not_to include("</div>")
-        expect(present).not_to include("<a")
-        expect(changes).not_to include("</div>")
+        # The Reason names the adjacency position (#137 contract).
+        expect(changes).to include("Whitespace")
       end
     end
   end

--- a/spec/canon/comparison/parse_error_surface_spec.rb
+++ b/spec/canon/comparison/parse_error_surface_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "canon/diff_formatter"
+
+# Issue #130: Canon's XML parser silently drops content on FATAL libxml
+# errors (e.g. duplicate-attribute violations).  The diff layer then
+# reports against a parse tree that no longer represents the input,
+# producing reports that read as nonsense to the user.  This spec
+# exercises the parse-error surface that propagates libxml's error list
+# all the way to ComparisonResult and the diff banner.
+RSpec.describe "parse error surface (issue #130)" do
+  let(:formatter) { Canon::DiffFormatter.new(use_color: false) }
+
+  describe "duplicate xml:lang in XML mode" do
+    let(:expected) do
+      '<body lang="en" xml:lang="en"><div class="x">x</div></body>'
+    end
+    let(:received) do
+      '<body lang="en" xml:lang="en" xml:lang="en"><div class="x">x</div></body>'
+    end
+    let(:result) do
+      Canon::Comparison.equivalent?(expected, received,
+                                    format: :xml, verbose: true)
+    end
+
+    it "surfaces the libxml FATAL on the received side" do
+      expect(result.parse_errors_received).not_to be_empty
+      expect(result.parse_errors_received.join("\n"))
+        .to match(/Attribute xml:lang redefined/)
+    end
+
+    it "leaves the expected side's parse_errors empty" do
+      expect(result.parse_errors_expected).to eq([])
+    end
+
+    it "answers parse_errors? truthfully" do
+      expect(result.parse_errors?).to be true
+    end
+
+    it "renders a banner at the top of the diff report" do
+      output = formatter.format_comparison_result(result, expected, received)
+      banner_line = output.lines.find { |l| l.include?("⚠️  PARSE ERRORS") }
+      expect(banner_line).not_to be_nil
+      expect(output).to include("Received side:")
+      expect(output).to include("Attribute xml:lang redefined")
+      expect(output)
+        .to include("describes the parsed tree, not the input")
+    end
+
+    it "renders the banner before the semantic diff section" do
+      output = formatter.format_comparison_result(result, expected, received)
+      banner_idx = output.index("PARSE ERRORS")
+      report_idx = output.index("SEMANTIC DIFF REPORT")
+      expect(banner_idx).not_to be_nil
+      expect(report_idx).not_to be_nil
+      expect(banner_idx).to be < report_idx
+    end
+  end
+
+  describe "valid XML on both sides" do
+    let(:expected) { "<root><a>1</a><b>2</b></root>" }
+    let(:received) { "<root><a>1</a><b>3</b></root>" }
+    let(:result) do
+      Canon::Comparison.equivalent?(expected, received,
+                                    format: :xml, verbose: true)
+    end
+
+    it "leaves both parse_errors arrays empty" do
+      expect(result.parse_errors_expected).to eq([])
+      expect(result.parse_errors_received).to eq([])
+    end
+
+    it "answers parse_errors? false" do
+      expect(result.parse_errors?).to be false
+    end
+
+    it "does not render a banner" do
+      output = formatter.format_comparison_result(result, expected, received)
+      expect(output).not_to include("PARSE ERRORS")
+    end
+  end
+
+  describe "duplicate attribute in HTML5 mode (no error to surface)" do
+    let(:expected) do
+      '<body lang="en" xml:lang="en"><div>x</div></body>'
+    end
+    let(:received) do
+      '<body lang="en" xml:lang="en" xml:lang="en"><div>x</div></body>'
+    end
+
+    it "does not record a parse error (HTML5 dedupes silently per spec)" do
+      result = Canon::Comparison.equivalent?(expected, received,
+                                             format: :html5, verbose: true)
+      expect(result.parse_errors_expected).to eq([])
+      expect(result.parse_errors_received).to eq([])
+      expect(result.parse_errors?).to be false
+    end
+  end
+end

--- a/spec/canon/comparison/whitespace_adjacency_spec.rb
+++ b/spec/canon/comparison/whitespace_adjacency_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Regression tests for the :whitespace_adjacency diff dimension (issue #137).
+#
+# The contract is REPORT-ONLY:
+#
+# * Equivalence verdict is identical to pre-#137 behaviour — when expected has
+#   asymmetric whitespace-only text nodes the actual side lacks, the
+#   comparison is still UNEQUAL.  No tests start passing because of this
+#   feature; existing whitespace-mismatch failures continue to fail.
+#
+# * Diff REPORT shape changes — instead of a 3-4 entry cascade of
+#   :text_content mismatches that pair stray whitespace against neighbouring
+#   content nodes (positional zip artefact), the report carries one
+#   :whitespace_adjacency entry per stray whitespace node, anchored at the
+#   node itself.
+
+RSpec.describe ":whitespace_adjacency diff dimension (#137)" do
+  context "asymmetric pretty-print whitespace inside HTML <p>" do
+    # Reproduces the metanorma-iso iso_spec.rb:114 cascade input shape
+    # (HTML mixed-content where positional zip was previously cascading
+    # mismatches across content siblings).
+    let(:expected_html) do
+      "<p><span>ISO </span>\n  <span>20483</span>\n  ,\n  <i>Cereals and pulses</i></p>"
+    end
+
+    let(:actual_html) do
+      "<p><span>ISO </span><span>20483</span>, <i>Cereals and pulses</i></p>"
+    end
+
+    def compare_html(html1, html2) # rubocop:disable Naming/PredicateMethod
+      Canon::Comparison.equivalent?(html1, html2, format: :html5, verbose: true)
+    end
+
+    it "still reports the inputs as non-equivalent (verdict unchanged from pre-#137)" do
+      result = compare_html(expected_html, actual_html)
+      expect(result.equivalent?).to be false
+    end
+
+    it "emits at least one :whitespace_adjacency diff anchored at a stray whitespace node" do
+      result = compare_html(expected_html, actual_html)
+      ws_adj = result.differences.select do |d|
+        d.dimension == :whitespace_adjacency
+      end
+      expect(ws_adj).not_to be_empty
+    end
+
+    it "does not emit a :text_content cascade pairing whitespace against content" do
+      result = compare_html(expected_html, actual_html)
+      bad_pairs = result.differences.select do |d|
+        next false unless d.dimension == :text_content
+
+        n1_text = node_text_for(d.respond_to?(:node1) ? d.node1 : nil)
+        n2_text = node_text_for(d.respond_to?(:node2) ? d.node2 : nil)
+        next false unless n1_text && n2_text
+
+        (n1_text.strip.empty? && !n2_text.strip.empty?) ||
+          (!n1_text.strip.empty? && n2_text.strip.empty?)
+      end
+      expect(bad_pairs).to be_empty
+    end
+  end
+
+  context "fully symmetric whitespace (no asymmetry)" do
+    let(:html) do
+      "<p><span>a</span>\n  <span>b</span></p>"
+    end
+
+    it "does not emit :whitespace_adjacency when both sides match" do
+      result = Canon::Comparison.equivalent?(
+        html, html, format: :html5, verbose: true
+      )
+      ws_adj = result.differences.select do |d|
+        d.dimension == :whitespace_adjacency
+      end
+      expect(ws_adj).to be_empty
+    end
+  end
+
+  def node_text_for(node)
+    return nil if node.nil?
+
+    if node.respond_to?(:value) && !node.respond_to?(:element?)
+      node.value.to_s
+    elsif node.respond_to?(:content)
+      node.content.to_s
+    end
+  end
+end

--- a/spec/canon/diff_formatter/diff_detail_formatter_spec.rb
+++ b/spec/canon/diff_formatter/diff_detail_formatter_spec.rb
@@ -508,7 +508,7 @@ RSpec.describe "DiffDetailFormatter helpers" do
       comparison_result = double("comparison_result")
       allow(comparison_result).to receive(:is_a?).with(Canon::Comparison::ComparisonResult).and_return(true)
       allow(comparison_result).to receive_messages(algorithm: :dom,
-                                                   differences: [diff], equivalent?: false, original_strings: ["<root/>", "<root/>"], html_version: nil, match_options: nil)
+                                                   differences: [diff], equivalent?: false, original_strings: ["<root/>", "<root/>"], html_version: nil, match_options: nil, parse_errors?: false, parse_errors_expected: [], parse_errors_received: [])
 
       output = formatter.format_comparison_result(comparison_result, "<root/>",
                                                   "<root/>")
@@ -572,7 +572,7 @@ RSpec.describe "DiffDetailFormatter helpers" do
       comparison_result = double("comparison_result")
       allow(comparison_result).to receive(:is_a?).with(Canon::Comparison::ComparisonResult).and_return(true)
       allow(comparison_result).to receive_messages(algorithm: :dom,
-                                                   differences: [diff], equivalent?: false, original_strings: ["<root/>", "<root/>"], html_version: nil, match_options: nil)
+                                                   differences: [diff], equivalent?: false, original_strings: ["<root/>", "<root/>"], html_version: nil, match_options: nil, parse_errors?: false, parse_errors_expected: [], parse_errors_received: [])
 
       output = formatter.format_comparison_result(comparison_result, "<root/>",
                                                   "<root/>")

--- a/spec/canon/diff_formatter/diff_detail_formatter_spec.rb
+++ b/spec/canon/diff_formatter/diff_detail_formatter_spec.rb
@@ -505,10 +505,18 @@ RSpec.describe "DiffDetailFormatter helpers" do
         compact_semantic_report: true,
       )
       # Simulate comparison_result
-      comparison_result = double("comparison_result")
+      comparison_result = double("comparison_result",
+                                 algorithm: :dom,
+                                 differences: [diff],
+                                 equivalent?: false,
+                                 original_strings: ["<root/>", "<root/>"],
+                                 html_version: nil,
+                                 match_options: nil,
+                                 parse_errors?: false,
+                                 parse_errors_expected: [],
+                                 parse_errors_received: [])
       allow(comparison_result).to receive(:is_a?).with(Canon::Comparison::ComparisonResult).and_return(true)
-      allow(comparison_result).to receive_messages(algorithm: :dom,
-                                                   differences: [diff], equivalent?: false, original_strings: ["<root/>", "<root/>"], html_version: nil, match_options: nil, parse_errors?: false, parse_errors_expected: [], parse_errors_received: [])
+      allow(comparison_result).to receive(:format).and_return(:xml)
 
       output = formatter.format_comparison_result(comparison_result, "<root/>",
                                                   "<root/>")
@@ -569,10 +577,18 @@ RSpec.describe "DiffDetailFormatter helpers" do
         use_color: false,
         expand_difference: true,
       )
-      comparison_result = double("comparison_result")
+      comparison_result = double("comparison_result",
+                                 algorithm: :dom,
+                                 differences: [diff],
+                                 equivalent?: false,
+                                 original_strings: ["<root/>", "<root/>"],
+                                 html_version: nil,
+                                 match_options: nil,
+                                 parse_errors?: false,
+                                 parse_errors_expected: [],
+                                 parse_errors_received: [])
       allow(comparison_result).to receive(:is_a?).with(Canon::Comparison::ComparisonResult).and_return(true)
-      allow(comparison_result).to receive_messages(algorithm: :dom,
-                                                   differences: [diff], equivalent?: false, original_strings: ["<root/>", "<root/>"], html_version: nil, match_options: nil, parse_errors?: false, parse_errors_expected: [], parse_errors_received: [])
+      allow(comparison_result).to receive(:format).and_return(:xml)
 
       output = formatter.format_comparison_result(comparison_result, "<root/>",
                                                   "<root/>")

--- a/spec/canon/pretty_printer/html_spec.rb
+++ b/spec/canon/pretty_printer/html_spec.rb
@@ -77,5 +77,71 @@ RSpec.describe Canon::PrettyPrinter::Html do
         expect(result).to include("nested content")
       end
     end
+
+    # Issue #133: Nokogiri::HTML5#to_html silently ignored the
+    # +indent:+ option, producing a single-line blob inside the
+    # PRETTY-PRINTED INPUTS section.  These specs lock the new
+    # +fixture_ready: true+ mode that uses
+    # +write_to(save_with: FORMAT|AS_XHTML|NO_DECLARATION)+ to
+    # actually indent.  The default (non-fixture-ready) mode is
+    # untouched -- existing callers that depend on its
+    # structurally-faithful behaviour are unaffected.
+    context "indentation behaviour (issue #133)" do
+      subject { described_class.new(indent: 2, fixture_ready: true) }
+
+      it "indents Word-flavoured HTML5 input (no XHTML doctype, no default xmlns)" do
+        # Real-world reproducer: Word output starts with
+        # `<html xmlns:epub="..." lang="en">` — no XHTML DOCTYPE, no
+        # `xmlns="http://www.w3.org/1999/xhtml"` declaration.  Before
+        # the fix, this took the broken format_as_html branch.
+        input = '<html xmlns:epub="http://www.idpf.org/2007/ops" ' \
+                'lang="en"><head><meta http-equiv="Content-Type" ' \
+                'content="text/html; charset=UTF-8"/></head>' \
+                '<body><div class="WordSection2">' \
+                '<p class="page-break"><br clear="all"/></p></div></body></html>'
+
+        result = subject.format(input)
+
+        # Multiple lines.
+        expect(result.lines.length).to be > 5
+        # At least one indented child element.
+        expect(result).to match(/\n  </)
+        # The original <body>'s children appear on separate lines
+        # rather than as a single blob.
+        expect(result).to match(/<body[^>]*>\s*\n\s+</)
+      end
+
+      it "indents plain HTML5 doctype input" do
+        input = "<!DOCTYPE html>\n" \
+                "<html><body><div><p>x</p></div></body></html>"
+
+        result = subject.format(input)
+
+        expect(result.lines.length).to be > 5
+        expect(result).to match(/<body>\s*\n\s+<div>/)
+        expect(result).to match(/<div>\s*\n\s+<p>/)
+      end
+
+      it "indents XHTML-shaped input" do
+        input = "<html xmlns=\"http://www.w3.org/1999/xhtml\">" \
+                "<body><p>x</p></body></html>"
+
+        result = subject.format(input)
+
+        expect(result.lines.length).to be > 3
+        expect(result).to match(/<body>\s*\n\s+<p>/)
+      end
+
+      it "preserves element count through the round-trip" do
+        # A cheap regression guard: the serializer must not drop
+        # content during pretty-print.
+        input = "<html xmlns:epub=\"x\" lang=\"en\">" \
+                "<body><div><p>a</p><p>b</p><p>c</p></div></body></html>"
+        result = subject.format(input)
+
+        out_count = Nokogiri::XML(result).search("p").length
+        expect(out_count).to eq(3)
+      end
+    end
   end
 end

--- a/spec/canon/pretty_printer/html_spec.rb
+++ b/spec/canon/pretty_printer/html_spec.rb
@@ -143,5 +143,46 @@ RSpec.describe Canon::PrettyPrinter::Html do
         expect(out_count).to eq(3)
       end
     end
+
+    context "fixture_ready: true — XHTML shape (regression #135)" do
+      subject { described_class.new(indent: 2, fixture_ready: true) }
+
+      it "emits XHTML shape: void self-closed, non-void paired" do
+        result = subject.format('<html><body><a href="#"></a><br><img src="y"><hr></body></html>')
+        expect(result).to include('<a href="#"></a>')
+        expect(result).to match(%r{<br\s*/>})
+        expect(result).to match(%r{<img src="y"\s*/>})
+        expect(result).to match(%r{<hr\s*/>})
+        expect(result).not_to match(%r{<a [^>]*/>})
+      end
+    end
+
+    context "regression #135 — XHTML branch must not self-close non-void elements" do
+      subject { described_class.new(indent: 2) }
+
+      let(:xhtml) do
+        <<~XHTML
+          <?xml version="1.0"?>
+          <html xmlns="http://www.w3.org/1999/xhtml"><body><a href="x"></a><span></span><div></div><br/><img src="y"/><hr/></body></html>
+        XHTML
+      end
+
+      it "writes empty non-void elements as <tag></tag>" do
+        result = subject.format(xhtml)
+        expect(result).to include('<a href="x"></a>')
+        expect(result).to include("<span></span>")
+        expect(result).to include("<div></div>")
+        expect(result).not_to match(%r{<a [^>]*/>})
+        expect(result).not_to include("<span/>")
+        expect(result).not_to include("<div/>")
+      end
+
+      it "leaves void elements self-closed (XHTML shape)" do
+        result = subject.format(xhtml)
+        expect(result).to include("<br/>")
+        expect(result).to include('<img src="y"/>')
+        expect(result).to include("<hr/>")
+      end
+    end
   end
 end

--- a/spec/canon/pretty_printer/xml_normalized_spec.rb
+++ b/spec/canon/pretty_printer/xml_normalized_spec.rb
@@ -544,4 +544,32 @@ RSpec.describe Canon::PrettyPrinter::XmlNormalized do
       expect(result).to include('c="3" a:y="2" b:x="1"')
     end
   end
+
+  describe "html_mode (regression #135)" do
+    let(:html_printer) { described_class.new(indent: 2, html_mode: true) }
+
+    it "writes empty non-void elements as <tag></tag>" do
+      html = '<div><a href="x"></a><span></span></div>'
+      result = html_printer.format(html)
+      expect(result).to include('<a href="x"></a>')
+      expect(result).to include("<span></span>")
+      expect(result).not_to match(%r{<a [^>]*/>})
+      expect(result).not_to include("<span/>")
+    end
+
+    it "self-closes void elements (XHTML shape) without nesting siblings" do
+      html = '<div><br><img src="y"><p>after</p></div>'
+      result = html_printer.format(html)
+      expect(result).to include("<br/>")
+      expect(result).to include('<img src="y"/>')
+      expect(result).not_to include("</br>")
+      expect(result).not_to include("</img>")
+      expect(result).to include("<p>")
+    end
+
+    it "leaves XML mode (html_mode: false) behaviour unchanged" do
+      xml = "<root><empty/></root>"
+      expect(printer.format(xml)).to include("<empty/>")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Combines and refactors contributions from issues #130, #133, #135, #137 (original PRs #131, #134, #136, #138) into a single properly-architected PR.

### Issues addressed

- **#130** — Surface XML/HTML parse errors at the top of the diff report
- **#133** — Actually indent HTML in fixture-ready pretty-print  
- **#135** — HTML pretty-print emits XHTML shape (no `<a/>`, no void-as-container nesting)
- **#137** — Asymmetric whitespace adjacency detection with `:whitespace_adjacency` dimension

### Architecture

All code follows the project architectural rules:

- **No `respond_to?`** — All type dispatch uses `is_a?` with known types (`Canon::Xml::Node`, `Nokogiri::XML::Node`, etc.)
- **No `send` for private methods** — `compare_nodes` made public on `XmlComparator`; all `ChildComparison` delegation uses direct public method calls
- **Single `NodeInspector` module** — One source of truth for cross-backend node type operations (`text_node?`, `whitespace_only_text?`, `text_content`, `parse_errors`)
- **Type dispatch via `case/when`** — `DiffNodeBuilder.extract_text_content`, `DimensionFormatter.present_is_element?`, `NodeUtils.raw_text_value` all use `case/when` with `is_a?` instead of `respond_to?` chains

### New modules

- `Canon::Comparison::NodeInspector` — Single source of truth for cross-backend node type operations
- `Canon::PrettyPrinter::HtmlVoidElements` — HTML5 void element name constants
- `:whitespace_adjacency` diff dimension for asymmetric whitespace reporting

### Test coverage

- All 2181 examples pass
- New specs for parse error surface, whitespace adjacency, HTML pretty-print, XML normalized
- Tests use real `Canon::Xml::Nodes::TextNode` objects instead of RSpec doubles
