### PR TITLE
fix: consolidate node type-checking into NodeInspector, fix Nokogiri text_node? bug

### DIFF
--- a/lib/canon/comparison/markup_comparator.rb
+++ b/lib/canon/comparison/markup_comparator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../comparison" # Load base module with constants
+require_relative "node_inspector"
 require_relative "../diff/diff_node"
 require_relative "../diff/path_builder"
 
@@ -87,23 +88,20 @@ module Canon
           return nil if node.nil?
 
           # Canon::Xml::Node types
-          if node.is_a?(Canon::Xml::Nodes::RootNode)
+          case node
+          when Canon::Xml::Nodes::RootNode
             # Serialize all children of root
             node.children.map { |child| serialize_node(child) }.join
-          elsif node.is_a?(Canon::Xml::Nodes::ElementNode)
+          when Canon::Xml::Nodes::ElementNode
             serialize_element_node(node)
-          elsif node.is_a?(Canon::Xml::Nodes::TextNode)
+          when Canon::Xml::Nodes::TextNode
             # Use original text (with entity references) if available,
             # otherwise fall back to value (decoded text)
             node.original || node.value
-          elsif node.is_a?(Canon::Xml::Nodes::CommentNode)
+          when Canon::Xml::Nodes::CommentNode
             "<!--#{node.value}-->"
-          elsif node.is_a?(Canon::Xml::Nodes::ProcessingInstructionNode)
+          when Canon::Xml::Nodes::ProcessingInstructionNode
             "<?#{node.target} #{node.data}?>"
-          elsif node.respond_to?(:to_xml)
-            node.to_xml
-          elsif node.respond_to?(:to_html)
-            node.to_html
           else
             node.to_s
           end
@@ -121,8 +119,8 @@ module Canon
             node.attribute_nodes.to_h do |attr|
               [attr.name, attr.value]
             end
-          # Nokogiri nodes
-          elsif node.respond_to?(:attributes)
+          # Nokogiri elements
+          elsif node.is_a?(Nokogiri::XML::Element)
             node.attributes.to_h do |_, attr|
               [attr.name, attr.value]
             end
@@ -227,8 +225,8 @@ module Canon
         def same_node_type?(node1, node2)
           return false if node1.class != node2.class
 
-          # For Nokogiri/Canon::Xml nodes, check node type
-          if node1.respond_to?(:node_type) && node2.respond_to?(:node_type)
+          case node1
+          when Canon::Xml::Node, Nokogiri::XML::Node
             node1.node_type == node2.node_type
           else
             true
@@ -245,20 +243,7 @@ module Canon
         # @param node [Object] Node to check
         # @return [Boolean] true if node is a comment
         def comment_node?(node)
-          return true if node.respond_to?(:comment?) && node.comment?
-          return true if node.respond_to?(:node_type) && node.node_type == :comment
-
-          # HTML comments are parsed as TEXT nodes by Nokogiri
-          # Check if this is a text node with HTML comment content
-          if text_node?(node)
-            text = node_text(node)
-            # Strip whitespace and backslashes for comparison
-            # Nokogiri escapes HTML comments as "<\\!-- comment -->" in full documents
-            text_stripped = text.to_s.strip.gsub("\\", "")
-            return true if text_stripped.start_with?("<!--") && text_stripped.end_with?("-->")
-          end
-
-          false
+          NodeInspector.comment_node?(node)
         end
 
         # Check if a node is a text node
@@ -266,9 +251,7 @@ module Canon
         # @param node [Object] Node to check
         # @return [Boolean] true if node is a text node
         def text_node?(node)
-          (node.respond_to?(:text?) && node.text? &&
-            !node.respond_to?(:element?)) ||
-            (node.respond_to?(:node_type) && node.node_type == :text)
+          NodeInspector.text_node?(node)
         end
 
         # Get text content from a node
@@ -276,15 +259,7 @@ module Canon
         # @param node [Object] Node to get text from
         # @return [String] Text content
         def node_text(node)
-          # Canon::Xml::Node TextNode uses .value
-          if node.respond_to?(:value)
-            node.value.to_s
-          # Nokogiri nodes use .content
-          elsif node.respond_to?(:content)
-            node.content.to_s
-          else
-            node.to_s
-          end
+          NodeInspector.text_content(node)
         end
 
         # Check if difference between two texts is only whitespace
@@ -371,26 +346,18 @@ module Canon
         def extract_text_content_from_node(node)
           return nil if node.nil?
 
-          # For Canon::Xml::Nodes::TextNode
-          return node.value if node.respond_to?(:value) && node.is_a?(Canon::Xml::Nodes::TextNode)
-
-          # For XML/HTML nodes with text_content method
-          return node.text_content if node.respond_to?(:text_content)
-
-          # For nodes with text method
-          return node.text if node.respond_to?(:text)
-
-          # For nodes with content method (Moxml::Text)
-          return node.content if node.respond_to?(:content)
-
-          # For nodes with value method (other types)
-          return node.value if node.respond_to?(:value)
-
-          # For simple text nodes or strings
-          return node.to_s if node.is_a?(String)
-
-          # For other node types, try to_s
-          node.to_s
+          case node
+          when Canon::Xml::Nodes::TextNode
+            node.value
+          when Canon::Xml::Node
+            node.text_content
+          when Nokogiri::XML::Node
+            node.content.to_s
+          when String
+            node
+          else
+            node.to_s
+          end
         rescue StandardError
           nil
         end
@@ -454,8 +421,8 @@ module Canon
         # @param node [Object] The node to check
         # @return [Symbol] The dimension symbol
         def determine_node_dimension(node)
-          # Canon::Xml::Node types
-          if node.respond_to?(:node_type) && node.node_type.is_a?(Symbol)
+          case node
+          when Canon::Xml::Node
             case node.node_type
             when :element then :element_structure
             when :comment then :comments
@@ -463,18 +430,18 @@ module Canon
             when :processing_instruction then :processing_instructions
             else :text_content
             end
-          # Moxml/Nokogiri types: check element? before the catch-all
-          # default so element orphans are correctly classified.
-          elsif node.respond_to?(:comment?) && node.comment?
-            :comments
-          elsif node.respond_to?(:text?) && node.text?
-            :text_content
-          elsif node.respond_to?(:cdata?) && node.cdata?
-            :text_content
-          elsif node.respond_to?(:processing_instruction?) && node.processing_instruction?
-            :processing_instructions
-          elsif node.is_a?(Nokogiri::XML::Element)
-            :element_structure
+          when Nokogiri::XML::Node
+            if node.comment?
+              :comments
+            elsif node.text? || node.cdata?
+              :text_content
+            elsif node.processing_instruction?
+              :processing_instructions
+            elsif node.element?
+              :element_structure
+            else
+              :text_content
+            end
           else
             :text_content
           end

--- a/lib/canon/comparison/node_inspector.rb
+++ b/lib/canon/comparison/node_inspector.rb
@@ -50,6 +50,39 @@ module Canon
         !text.empty? && text.strip.empty?
       end
 
+      # True when +node+ is a comment node.
+      # For HTML, also detects comments that Nokogiri parses as TEXT nodes
+      # (content like "<!-- comment -->" or escaped "<\\!-- comment -->").
+      def self.comment_node?(node)
+        case node
+        when Canon::Xml::Node
+          node.node_type == :comment
+        when Nokogiri::XML::Node
+          return true if node.comment?
+
+          # HTML comments are parsed as TEXT nodes by Nokogiri
+          if node.text?
+            text_stripped = text_content(node).to_s.strip.gsub("\\", "")
+            return true if text_stripped.start_with?("<!--") && text_stripped.end_with?("-->")
+          end
+          false
+        else
+          false
+        end
+      end
+
+      # True when +node+ is an element node.
+      def self.element_node?(node)
+        case node
+        when Canon::Xml::Node
+          node.node_type == :element
+        when Nokogiri::XML::Node
+          node.element?
+        else
+          false
+        end
+      end
+
       # Extract parse-time errors carried on a node or its owning document.
       # Returns an Array of Strings.
       def self.parse_errors(node)

--- a/lib/canon/comparison/xml_node_comparison.rb
+++ b/lib/canon/comparison/xml_node_comparison.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "node_inspector"
+
 module Canon
   module Comparison
     # XML Node Comparison Utilities
@@ -180,13 +182,9 @@ differences)
       # @return [Symbol] Comparison result constant
       def self.dispatch_by_node_type(node1, node2, opts, child_opts,
 diff_children, differences)
-        # Canon::Xml::Node types use .node_type method that returns symbols
-        # Nokogiri also has .node_type but returns integers, so check for Symbol
-        if node1.respond_to?(:node_type) && node2.respond_to?(:node_type) &&
-            node1.node_type.is_a?(Symbol) && node2.node_type.is_a?(Symbol)
+        if node1.is_a?(Canon::Xml::Node) && node2.is_a?(Canon::Xml::Node)
           dispatch_canon_node_type(node1, node2, opts, child_opts,
                                    diff_children, differences)
-        # Moxml/Nokogiri types use .element?, .text?, etc. methods
         else
           dispatch_legacy_node_type(node1, node2, opts, child_opts,
                                     diff_children, differences)
@@ -286,8 +284,8 @@ diff_children, differences)
       def self.same_node_type?(node1, node2)
         return false if node1.class != node2.class
 
-        # For Nokogiri/Canon::Xml nodes, check node type
-        if node1.respond_to?(:node_type) && node2.respond_to?(:node_type)
+        case node1
+        when Canon::Xml::Node, Nokogiri::XML::Node
           node1.node_type == node2.node_type
         else
           true
@@ -305,34 +303,13 @@ diff_children, differences)
       # @param check_children [Boolean] Whether to check child nodes
       # @return [Boolean] true if node is a comment
       def self.comment_node?(node, check_children: false)
-        result = false
-        return true if node.respond_to?(:comment?) && node.comment?
-        return true if node.respond_to?(:node_type) && node.node_type == :comment
+        return true if NodeInspector.comment_node?(node)
 
-        if node.is_a?(Nokogiri::XML::Element) && !node.children.empty? && check_children
-          node.children.each do |child|
-            # Recursively check child nodes for comments
-            # limit depth to avoid infinite recursion
-            # in case of circular structures (if any)
-            if comment_node?(child, check_children: false)
-              result = true
-              break
-            end
-          end
+        if check_children && node.is_a?(Nokogiri::XML::Element) && !node.children.empty?
+          node.children.any? { |child| NodeInspector.comment_node?(child) }
+        else
+          false
         end
-        return true if result
-
-        # HTML comments are parsed as TEXT nodes by Nokogiri
-        # Check if this is a text node with HTML comment content
-        if text_node?(node)
-          text = node_text(node)
-          # Strip whitespace and backslashes for comparison
-          # Nokogiri escapes HTML comments as "<\\!-- comment -->" in full documents
-          text_stripped = text.to_s.strip.gsub("\\", "")
-          return true if text_stripped.start_with?("<!--") && text_stripped.end_with?("-->")
-        end
-
-        result
       end
 
       # Check if a node is a text node
@@ -340,24 +317,7 @@ diff_children, differences)
       # @param node [Object] Node to check
       # @return [Boolean] true if node is a text node
       def self.text_node?(node)
-        return false unless node
-
-        # Nokogiri text nodes (XML, HTML4, HTML5) — call element? rather
-        # than respond_to?(:element?), which always returns true for
-        # Nokogiri::XML::Node and made this predicate vacuously false
-        # for every Nokogiri text node. See issue #118.
-        if node.is_a?(Nokogiri::XML::Node)
-          return node.text? && !node.element?
-        end
-
-        # Canon::Xml::Nodes types and other ducktyped nodes.
-        if node.respond_to?(:text?) && node.text? &&
-            !node.respond_to?(:element?)
-          return true
-        end
-
-        # Symbol-style node_type (Canon's own node objects).
-        node.respond_to?(:node_type) && node.node_type == :text
+        NodeInspector.text_node?(node)
       end
 
       # Extract text content from a node
@@ -367,15 +327,7 @@ diff_children, differences)
       def self.node_text(node)
         return "" unless node
 
-        if node.respond_to?(:content)
-          node.content.to_s
-        elsif node.respond_to?(:text)
-          node.text.to_s
-        elsif node.respond_to?(:value)
-          node.value.to_s
-        else
-          ""
-        end
+        NodeInspector.text_content(node)
       end
 
       # Dispatch by Canon::Xml::Node type
@@ -411,21 +363,26 @@ diff_children, differences)
         # Import XmlComparator to use its comparison methods
         require_relative "xml_comparator"
 
-        if node1.respond_to?(:element?) && node1.element?
-          XmlComparator.compare_element_nodes(node1, node2, opts, child_opts,
-                                              diff_children, differences)
-        elsif node1.respond_to?(:text?) && node1.text?
-          XmlComparator.compare_text_nodes(node1, node2, opts, differences)
-        elsif node1.respond_to?(:comment?) && node1.comment?
-          XmlComparator.compare_comment_nodes(node1, node2, opts, differences)
-        elsif node1.respond_to?(:cdata?) && node1.cdata?
-          XmlComparator.compare_text_nodes(node1, node2, opts, differences)
-        elsif node1.respond_to?(:processing_instruction?) && node1.processing_instruction?
-          XmlComparator.compare_processing_instruction_nodes(node1, node2,
-                                                             opts, differences)
-        elsif node1.respond_to?(:root)
+        case node1
+        when Nokogiri::XML::Document
           XmlComparator.compare_document_nodes(node1, node2, opts, child_opts,
                                                diff_children, differences)
+        when Nokogiri::XML::Node
+          if node1.element?
+            XmlComparator.compare_element_nodes(node1, node2, opts, child_opts,
+                                                diff_children, differences)
+          elsif node1.text?
+            XmlComparator.compare_text_nodes(node1, node2, opts, differences)
+          elsif node1.comment?
+            XmlComparator.compare_comment_nodes(node1, node2, opts, differences)
+          elsif node1.cdata?
+            XmlComparator.compare_text_nodes(node1, node2, opts, differences)
+          elsif node1.processing_instruction?
+            XmlComparator.compare_processing_instruction_nodes(node1, node2,
+                                                               opts, differences)
+          else
+            Comparison::EQUIVALENT
+          end
         else
           Comparison::EQUIVALENT
         end
@@ -457,10 +414,11 @@ differences)
       # @param node [Canon::Xml::Node, Object] Node to serialize
       # @return [String] XML string representation
       def self.serialize_node_to_xml(node)
-        if node.is_a?(Canon::Xml::Nodes::RootNode)
+        case node
+        when Canon::Xml::Nodes::RootNode
           # Serialize all children of root
           node.children.map { |child| serialize_node_to_xml(child) }.join
-        elsif node.is_a?(Canon::Xml::Nodes::ElementNode)
+        when Canon::Xml::Nodes::ElementNode
           # Serialize element with attributes and children
           attrs = node.attribute_nodes.map do |a|
             " #{a.name}=\"#{a.value}\""
@@ -474,14 +432,12 @@ differences)
           else
             "<#{node.name}#{attrs}>#{children_xml}</#{node.name}>"
           end
-        elsif node.is_a?(Canon::Xml::Nodes::TextNode)
+        when Canon::Xml::Nodes::TextNode
           node.value
-        elsif node.is_a?(Canon::Xml::Nodes::CommentNode)
+        when Canon::Xml::Nodes::CommentNode
           "<!--#{node.value}-->"
-        elsif node.is_a?(Canon::Xml::Nodes::ProcessingInstructionNode)
+        when Canon::Xml::Nodes::ProcessingInstructionNode
           "<?#{node.target} #{node.data}?>"
-        elsif node.respond_to?(:to_xml)
-          node.to_xml
         else
           node.to_s
         end

--- a/lib/canon/diff/diff_classifier.rb
+++ b/lib/canon/diff/diff_classifier.rb
@@ -220,28 +220,21 @@ module Canon
       def extract_text_content(node)
         return nil if node.nil?
 
-        # For TextNode with value attribute (Canon::Xml::Nodes::TextNode)
-        return node.value if node.respond_to?(:value) && node.is_a?(Canon::Xml::Nodes::TextNode)
-
-        # For XML/HTML nodes with text_content method
-        return node.text_content if node.respond_to?(:text_content)
-
-        # For nodes with text method
-        return node.text if node.respond_to?(:text)
-
-        # For nodes with content method
-        return node.content if node.respond_to?(:content)
-
-        # For nodes with value method (other types)
-        return node.value if node.respond_to?(:value)
-
-        # For simple text nodes or strings
-        return node.to_s if node.is_a?(String)
-
-        # For other node types, try to_s
-        node.to_s
+        case node
+        when Canon::Xml::Nodes::TextNode
+          node.value
+        when Canon::Xml::Node
+          node.text_content
+        when Nokogiri::XML::Node
+          node.content.to_s
+        when Moxml::Node
+          node.content.to_s
+        when String
+          node
+        else
+          node.to_s
+        end
       rescue StandardError
-        # If extraction fails, return nil (not formatting-only)
         nil
       end
 
@@ -251,25 +244,20 @@ module Canon
       def text_node?(node)
         return false if node.nil?
 
-        # Canon::Xml::Nodes::TextNode
-        return true if node.is_a?(Canon::Xml::Nodes::TextNode)
-
-        # Nokogiri text nodes (node_type returns integer constant like 3)
-        return true if node.respond_to?(:node_type) &&
-          node.node_type.is_a?(Integer) &&
+        case node
+        when Canon::Xml::Nodes::TextNode
+          true
+        when Canon::Xml::Node
+          node.node_type == :text
+        when Nokogiri::XML::Node
           node.node_type == Nokogiri::XML::Node::TEXT_NODE
-
-        # Moxml text nodes (node_type returns symbol)
-        return true if node.respond_to?(:node_type) && node.node_type == :text
-
-        # String
-        return true if node.is_a?(String)
-
-        # Test doubles or objects with text node-like interface
-        # Check if it has a value method (contains text content)
-        return true if node.respond_to?(:value)
-
-        false
+        when Moxml::Node
+          node.text?
+        when String
+          true
+        else
+          false
+        end
       end
     end
   end

--- a/lib/canon/diff/xml_serialization_formatter.rb
+++ b/lib/canon/diff/xml_serialization_formatter.rb
@@ -91,28 +91,20 @@ module Canon
       def self.text_node?(node)
         return false if node.nil?
 
-        # Canon::Xml::Nodes::TextNode
-        return true if node.is_a?(Canon::Xml::Nodes::TextNode)
-
-        # Moxml::Text (check before generic node_type check)
-        return true if node.is_a?(Moxml::Text)
-
-        # Nokogiri text nodes (node_type returns integer constant like 3)
-        return true if node.respond_to?(:node_type) &&
-          node.node_type.is_a?(Integer) &&
+        case node
+        when Canon::Xml::Nodes::TextNode
+          true
+        when Canon::Xml::Node
+          node.node_type == :text
+        when Nokogiri::XML::Node
           node.node_type == Nokogiri::XML::Node::TEXT_NODE
-
-        # Moxml text nodes (node_type returns symbol) - for when using Moxml adapters
-        return true if node.respond_to?(:node_type) && node.node_type == :text
-
-        # String
-        return true if node.is_a?(String)
-
-        # Test doubles or objects with text node-like interface
-        # Check if it has a value method (contains text content)
-        return true if node.respond_to?(:value)
-
-        false
+        when Moxml::Node
+          node.text?
+        when String
+          true
+        else
+          false
+        end
       end
 
       # Extract text content from a node
@@ -121,28 +113,21 @@ module Canon
       def self.extract_text_content(node)
         return nil if node.nil?
 
-        # For TextNode with value attribute (Canon::Xml::Nodes::TextNode)
-        return node.value if node.respond_to?(:value) && node.is_a?(Canon::Xml::Nodes::TextNode)
-
-        # For XML/HTML nodes with text_content method
-        return node.text_content if node.respond_to?(:text_content)
-
-        # For nodes with content method (try before text, as Moxml::Text.text returns "")
-        return node.content if node.respond_to?(:content)
-
-        # For nodes with text method
-        return node.text if node.respond_to?(:text)
-
-        # For nodes with value method (other types)
-        return node.value if node.respond_to?(:value)
-
-        # For simple text nodes or strings
-        return node.to_s if node.is_a?(String)
-
-        # For other node types, try to_s
-        node.to_s
+        case node
+        when Canon::Xml::Nodes::TextNode
+          node.value
+        when Canon::Xml::Node
+          node.text_content
+        when Nokogiri::XML::Node
+          node.content.to_s
+        when Moxml::Node
+          node.content.to_s
+        when String
+          node
+        else
+          node.to_s
+        end
       rescue StandardError
-        # If extraction fails, return nil (not a serialization difference)
         nil
       end
 

--- a/spec/canon/diff/diff_classifier_spec.rb
+++ b/spec/canon/diff/diff_classifier_spec.rb
@@ -152,10 +152,8 @@ RSpec.describe Canon::Diff::DiffClassifier do
         let(:classifier) { described_class.new(match_options) }
 
         it "classifies as formatting when only whitespace differs" do
-          text1 = double("TextNode")
-          text2 = double("TextNode")
-          allow(text1).to receive(:value).and_return("Hello  world")
-          allow(text2).to receive(:value).and_return("Hello world")
+          text1 = Canon::Xml::Nodes::TextNode.new(value: "Hello  world")
+          text2 = Canon::Xml::Nodes::TextNode.new(value: "Hello world")
 
           diff_node = Canon::Diff::DiffNode.new(
             node1: text1,
@@ -182,10 +180,8 @@ RSpec.describe Canon::Diff::DiffClassifier do
         let(:classifier) { described_class.new(match_options) }
 
         it "classifies as informative when content differs" do
-          text1 = double("TextNode")
-          text2 = double("TextNode")
-          allow(text1).to receive(:value).and_return("Hello")
-          allow(text2).to receive(:value).and_return("Goodbye")
+          text1 = Canon::Xml::Nodes::TextNode.new(value: "Hello")
+          text2 = Canon::Xml::Nodes::TextNode.new(value: "Goodbye")
 
           diff_node = Canon::Diff::DiffNode.new(
             node1: text1,
@@ -215,11 +211,8 @@ RSpec.describe Canon::Diff::DiffClassifier do
         let(:classifier) { described_class.new(match_options) }
 
         it "classifies whitespace differences as formatting" do
-          # Structural whitespace nodes with content that differs only in whitespace
-          ws1 = double("WhitespaceNode")
-          ws2 = double("WhitespaceNode")
-          allow(ws1).to receive(:value).and_return("<div>  content  </div>")
-          allow(ws2).to receive(:value).and_return("<div> content </div>")
+          ws1 = Canon::Xml::Nodes::TextNode.new(value: "<div>  content  </div>")
+          ws2 = Canon::Xml::Nodes::TextNode.new(value: "<div> content </div>")
 
           diff_node = Canon::Diff::DiffNode.new(
             node1: ws1,

--- a/spec/canon/diff/xml_serialization_formatter_spec.rb
+++ b/spec/canon/diff/xml_serialization_formatter_spec.rb
@@ -8,9 +8,8 @@ RSpec.describe Canon::Diff::XmlSerializationFormatter do
   describe ".serialization_formatting?" do
     context "with self-closing vs explicit closing tags" do
       it "detects empty text nodes from self-closing vs explicit closing" do
-        # Create mock text nodes
-        node1 = double("TextNode", value: "")
-        node2 = double("TextNode", value: "   ")
+        node1 = Canon::Xml::Nodes::TextNode.new(value: "")
+        node2 = Canon::Xml::Nodes::TextNode.new(value: "   ")
 
         diff_node = Canon::Diff::DiffNode.new(
           node1: node1,
@@ -23,8 +22,8 @@ RSpec.describe Canon::Diff::XmlSerializationFormatter do
       end
 
       it "detects whitespace-only text nodes from self-closing vs explicit closing" do
-        node1 = double("TextNode", value: "\n")
-        node2 = double("TextNode", value: "  \t  ")
+        node1 = Canon::Xml::Nodes::TextNode.new(value: "\n")
+        node2 = Canon::Xml::Nodes::TextNode.new(value: "  \t  ")
 
         diff_node = Canon::Diff::DiffNode.new(
           node1: node1,
@@ -37,8 +36,8 @@ RSpec.describe Canon::Diff::XmlSerializationFormatter do
       end
 
       it "returns false for non-text_content dimensions" do
-        node1 = double("TextNode", value: "")
-        node2 = double("TextNode", value: "")
+        node1 = Canon::Xml::Nodes::TextNode.new(value: "")
+        node2 = Canon::Xml::Nodes::TextNode.new(value: "")
 
         diff_node = Canon::Diff::DiffNode.new(
           node1: node1,
@@ -53,8 +52,8 @@ RSpec.describe Canon::Diff::XmlSerializationFormatter do
 
     context "with actual content differences" do
       it "returns false for text with actual content" do
-        node1 = double("TextNode", value: "Hello")
-        node2 = double("TextNode", value: "Goodbye")
+        node1 = Canon::Xml::Nodes::TextNode.new(value: "Hello")
+        node2 = Canon::Xml::Nodes::TextNode.new(value: "Goodbye")
 
         diff_node = Canon::Diff::DiffNode.new(
           node1: node1,
@@ -67,8 +66,8 @@ RSpec.describe Canon::Diff::XmlSerializationFormatter do
       end
 
       it "returns false when one text is blank and one has content" do
-        node1 = double("TextNode", value: "")
-        node2 = double("TextNode", value: "Hello")
+        node1 = Canon::Xml::Nodes::TextNode.new(value: "")
+        node2 = Canon::Xml::Nodes::TextNode.new(value: "Hello")
 
         diff_node = Canon::Diff::DiffNode.new(
           node1: node1,
@@ -226,10 +225,10 @@ RSpec.describe Canon::Diff::XmlSerializationFormatter do
       end
     end
 
-    context "with objects with value method" do
-      it "returns true for objects with value method" do
-        obj = double("TextNode", value: "text")
-        expect(described_class.send(:text_node?, obj)).to be true
+    context "with unknown objects" do
+      it "returns false for unknown objects without a recognized type" do
+        obj = Object.new
+        expect(described_class.send(:text_node?, obj)).to be false
       end
     end
 
@@ -293,31 +292,16 @@ RSpec.describe Canon::Diff::XmlSerializationFormatter do
       end
     end
 
-    context "with objects with various content methods" do
-      it "tries text_content method first" do
-        obj = double("Node", text_content: "via text_content", text: "via text")
+    context "with Canon::Xml::Node element nodes" do
+      it "extracts text_content from element nodes" do
+        node = Canon::Xml::Nodes::ElementNode.new(name: "p")
+        node.add_child(Canon::Xml::Nodes::TextNode.new(value: "via text_content"))
         expect(described_class.send(:extract_text_content,
-                                    obj)).to eq("via text_content")
+                                    node)).to eq("via text_content")
       end
+    end
 
-      it "falls back to text method" do
-        obj = double("Node", text: "via text")
-        expect(described_class.send(:extract_text_content,
-                                    obj)).to eq("via text")
-      end
-
-      it "falls back to content method" do
-        obj = double("Node", content: "via content")
-        expect(described_class.send(:extract_text_content,
-                                    obj)).to eq("via content")
-      end
-
-      it "falls back to value method" do
-        obj = double("Node", value: "via value")
-        expect(described_class.send(:extract_text_content,
-                                    obj)).to eq("via value")
-      end
-
+    context "with unknown objects" do
       it "falls back to to_s" do
         obj = double("Node", to_s: "via to_s")
         expect(described_class.send(:extract_text_content,
@@ -327,17 +311,17 @@ RSpec.describe Canon::Diff::XmlSerializationFormatter do
 
     context "with error handling" do
       it "returns nil when extraction raises an error" do
-        obj = double("Node")
-        allow(obj).to receive(:text_content).and_raise(StandardError, "error")
-        expect(described_class.send(:extract_text_content, obj)).to be_nil
+        node = Canon::Xml::Nodes::ElementNode.new(name: "p")
+        allow(node).to receive(:text_content).and_raise(StandardError, "error")
+        expect(described_class.send(:extract_text_content, node)).to be_nil
       end
     end
   end
 
   describe ".empty_text_content_serialization_diff?" do
     it "returns false for non-text_content dimensions" do
-      node1 = double("TextNode", value: "")
-      node2 = double("TextNode", value: "")
+      node1 = Canon::Xml::Nodes::TextNode.new(value: "")
+      node2 = Canon::Xml::Nodes::TextNode.new(value: "")
 
       diff_node = Canon::Diff::DiffNode.new(
         node1: node1,
@@ -351,8 +335,8 @@ RSpec.describe Canon::Diff::XmlSerializationFormatter do
     end
 
     it "returns false when nodes are not text nodes" do
-      node1 = double("ElementNode", name: "div")
-      node2 = double("ElementNode", name: "div")
+      node1 = Canon::Xml::Nodes::ElementNode.new(name: "div")
+      node2 = Canon::Xml::Nodes::ElementNode.new(name: "div")
 
       diff_node = Canon::Diff::DiffNode.new(
         node1: node1,
@@ -366,8 +350,8 @@ RSpec.describe Canon::Diff::XmlSerializationFormatter do
     end
 
     it "returns true when both texts are blank" do
-      node1 = double("TextNode", value: "")
-      node2 = double("TextNode", value: "   ")
+      node1 = Canon::Xml::Nodes::TextNode.new(value: "")
+      node2 = Canon::Xml::Nodes::TextNode.new(value: "   ")
 
       diff_node = Canon::Diff::DiffNode.new(
         node1: node1,
@@ -381,8 +365,8 @@ RSpec.describe Canon::Diff::XmlSerializationFormatter do
     end
 
     it "returns false when only one text is blank" do
-      node1 = double("TextNode", value: "")
-      node2 = double("TextNode", value: "text")
+      node1 = Canon::Xml::Nodes::TextNode.new(value: "")
+      node2 = Canon::Xml::Nodes::TextNode.new(value: "text")
 
       diff_node = Canon::Diff::DiffNode.new(
         node1: node1,


### PR DESCRIPTION
## Summary

Fixes the pre-existing `MarkupComparator.text_node?` Nokogiri bug identified in [issue #137 comment](https://github.com/lutaml/canon/issues/137#issuecomment-4365392428), and consolidates all duplicated type-checking logic into `NodeInspector` per the CLAUDE.md architectural rules.

## Problem

The contributor on #137 identified that `MarkupComparator#text_node?` is **vacuously false for all Nokogiri text nodes** because:
- Nokogiri responds to `:element?` (returns false), so `!node.respond_to?(:element?)` is false
- Nokogiri `node_type` returns Integer `3`, not Symbol `:text`

This bug was pre-existing — our PR #139 refactoring did not introduce it, but also did not fix it.

## Changes

### Core fix: delegate to NodeInspector
- `MarkupComparator.text_node?` → delegates to `NodeInspector.text_node?`
- `MarkupComparator.comment_node?` → delegates to `NodeInspector.comment_node?`
- `MarkupComparator.node_text` → delegates to `NodeInspector.text_content`
- `XmlNodeComparison.text_node?` → delegates to `NodeInspector.text_node?`
- `XmlNodeComparison.comment_node?` → delegates to `NodeInspector.comment_node?`
- `XmlNodeComparison.node_text` → delegates to `NodeInspector.text_content`

### Extend NodeInspector
- Added `comment_node?` — handles Canon::Xml::Node `:comment` type, Nokogiri `comment?` method, and HTML comments parsed as TEXT nodes
- Added `element_node?` — handles Canon::Xml::Node `:element` type and Nokogiri `element?` method

### Replace `respond_to?` with `case/when` + `is_a?`
- `MarkupComparator`: `serialize_node`, `extract_attributes`, `same_node_type?`, `extract_text_content_from_node`, `determine_node_dimension`
- `XmlNodeComparison`: `dispatch_by_node_type`, `dispatch_legacy_node_type`, `same_node_type?`, `serialize_node_to_xml`
- `DiffClassifier`: `text_node?`, `extract_text_content`
- `XmlSerializationFormatter`: `text_node?`, `extract_text_content`

### Test updates
- Replaced test doubles with real `Canon::Xml::Nodes::TextNode` objects where the tests exercised type dispatch
- Kept Moxml::Node handling in diff-layer `text_node?` / `extract_text_content` (Moxml is an available dependency)

## Test results
- 2178 examples, 0 failures, 1 pending (pre-existing)
- 298 files, 0 rubocop offenses
- Net: 202 insertions, 296 deletions (−94 lines)