### PR TITLE
fix: phrase :whitespace_adjacency Reason by partner direction (#137 follow-up)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -614,6 +614,10 @@ See link:docs/MODES[Diff modes] for details.
 * **Formatting diff detection**: Automatically detects and highlights purely cosmetic whitespace/line break differences
 * **Whitespace visualization**: Make invisible characters visible with CJK-safe
   Unicode symbols
+* **Whitespace adjacency reporting**: Stray whitespace-only text nodes are
+  reported as a dedicated `:whitespace_adjacency` dimension with direction
+  wording (`before`/`after`/`adjacent to`) instead of cascading into
+  misleading `:text_content` mismatches
 * **Non-ASCII detection**: Warnings for unexpected Unicode characters
 * **Customizable**: Character maps, context lines, grouping options
 

--- a/docs/advanced/diff-classification.adoc
+++ b/docs/advanced/diff-classification.adoc
@@ -266,6 +266,22 @@ match dimension but follows the same normative rule as all general dimensions:
   - Structural differences tracked but don't affect equivalence
   - Useful for content-only comparisons where wrapper elements don't matter
 
+==== Whitespace Adjacency
+
+`:whitespace_adjacency` is a derived dimension — emitted when the
+alignment walk pairs a whitespace-only text node on one side against a
+content node on the other. The Reason line describes the whitespace's
+direction relative to the partner content: `before`, `after`, or
+`adjacent to`.
+
+* **Always normative** — differences always affect equivalence
+* **Not user-configurable** — dimension is always tracked when the
+  re-alignment walk encounters an asymmetric whitespace node
+* **Report-only** — does not change equivalence outcomes compared to
+  pre-#137 behaviour; only changes the diff-report shape (see
+  link:../features/diff-formatting/whitespace-adjacency.adoc[Whitespace
+  adjacency] for details)
+
 .Example: Comment handling
 ====
 [source,ruby]

--- a/docs/features/diff-formatting/index.adoc
+++ b/docs/features/diff-formatting/index.adoc
@@ -30,7 +30,9 @@ Canon's diff formatting includes:
   algorithms
 * **Whitespace adjacency**: Stray whitespace-only text nodes are anchored at
   themselves instead of cascading into mismatches against neighbouring
-  content (link:./whitespace-adjacency.adoc[details])
+  content. The Reason line names the direction relative to the partner
+  (`before`/`after`/`adjacent to`)
+  (link:./whitespace-adjacency.adoc[details])
 
 == Available formatting options
 

--- a/docs/features/diff-formatting/whitespace-adjacency.adoc
+++ b/docs/features/diff-formatting/whitespace-adjacency.adoc
@@ -75,28 +75,39 @@ After the new contract, the cascade above collapses to:
 
 [source]
 ----
-DIFFERENCE #1 — whitespace_adjacency: Whitespace surrounding "20483":
+DIFFERENCE #1 — whitespace_adjacency: Whitespace before "20483":
                   present on EXPECTED ("↵░░"), absent on ACTUAL
-DIFFERENCE #2 — whitespace_adjacency: Whitespace surrounding ",":
+DIFFERENCE #2 — whitespace_adjacency: Whitespace before ",":
                   present on EXPECTED ("↵░░"), absent on ACTUAL
 DIFFERENCE #3 — text_content: "↵░░,↵░░"  vs  ", "
 ----
 
-== Adjacency positions
+== Direction relative to the partner
 
-The Reason line names the adjacency position of the whitespace node
-relative to its non-whitespace siblings:
+The Reason line names the document-order position of the whitespace
+node relative to the *partner content node* it was zipped against by
+the alignment walk. The partner is the next (or, at parent edge,
+previous) non-whitespace sibling on the whitespace-bearing side, which
+is what aligns against the corresponding content node on the other
+side.
 
-`:preceding`::  Whitespace at the start of its parent (no non-whitespace
-sibling before it, has one after it).
+`before`::  The whitespace immediately precedes its next non-whitespace
+sibling. This is the common case (e.g. indentation between two inline
+spans where the asymmetric whitespace sits on the leading edge of the
+partner).
 
-`:following`::  Whitespace at the end of its parent (has a non-whitespace
-sibling before it, none after).
+`after`::  The whitespace trails the previous non-whitespace sibling
+and has no non-whitespace sibling after it. Emitted at the trailing
+edge of a parent.
 
-`:surrounding`::  Sandwiched between two non-whitespace siblings.
+`adjacent to`::  Degenerate fallback for a whitespace node with no
+non-whitespace siblings at all. Rarely emitted.
 
-`:isolated`::  No non-whitespace siblings at all (degenerate; rarely
-emitted).
+NOTE: An earlier wording (`Whitespace surrounding "X"`) classified the
+*whitespace node's position among its own siblings* rather than its
+direction relative to the partner. That label was misleading when the
+whitespace sat between two element siblings but the asymmetry was
+one-sided — see issue #137 follow-up.
 
 == What this contract does NOT do
 

--- a/docs/features/diff-formatting/whitespace-adjacency.adoc
+++ b/docs/features/diff-formatting/whitespace-adjacency.adoc
@@ -109,6 +109,71 @@ direction relative to the partner. That label was misleading when the
 whitespace sat between two element siblings but the asymmetry was
 one-sided — see issue #137 follow-up.
 
+=== Examples
+
+==== "before" — whitespace between inline element siblings
+
+[source,ruby]
+----
+html1 = "<a><span>ISO </span>\n   <span>712</span></a>"
+html2 = "<a><span>ISO </span><span>712</span></a>"
+
+result = Canon::Comparison.equivalent?(html1, html2,
+  format: :html5, verbose: true)
+# => #<ComparisonResult equivalent=false>
+
+# The stray "\n   " between two spans is the only asymmetric node.
+# It sits immediately before <span>712</span>, its next non-ws sibling.
+result.differences.first.reason
+# => "Whitespace before \"712\": present on EXPECTED (\"░\"), absent on ACTUAL"
+----
+
+==== "after" — trailing whitespace in a whitespace-preserving element
+
+[source,ruby]
+----
+# <code> preserves whitespace, so the trailing newline survives the
+# upstream filter and pairs against the extra <b>B</b> on the other side.
+html1 = "<code><b>A</b>\n</code>"
+html2 = "<code><b>A</b><b>B</b></code>"
+
+result = Canon::Comparison.equivalent?(html1, html2,
+  format: :html5, verbose: true)
+result.differences.first.reason
+# => "Whitespace after \"B\": present on EXPECTED (\"↵\"), absent on ACTUAL"
+----
+
+==== "adjacent to" — sole-child whitespace node
+
+[source,ruby]
+----
+# A whitespace-only text node as the only child of <code>, paired
+# against an element on the other side.  No non-ws siblings exist.
+html1 = "<code>\n</code>"
+html2 = "<code><b>A</b></code>"
+
+result = Canon::Comparison.equivalent?(html1, html2,
+  format: :html5, verbose: true)
+result.differences.first.reason
+# => "Whitespace adjacent to \"A\": present on EXPECTED (\"↵\"), absent on ACTUAL"
+----
+
+== Working with :whitespace_adjacency diffs programmatically
+
+Use the `dimension` field on `DiffNode` to filter:
+
+[source,ruby]
+----
+result = Canon::Comparison.equivalent?(html1, html2,
+  format: :html5, verbose: true)
+
+# Find all whitespace-adjacency diffs
+ws_diffs = result.differences.select { |d| d.dimension == :whitespace_adjacency }
+
+# These are always normative — they affect the equivalence verdict
+ws_diffs.all?(&:normative?)  # => true
+----
+
 == What this contract does NOT do
 
 * **Does not change equivalence outcomes.** A non-equivalent comparison
@@ -148,4 +213,6 @@ whitespace node as a single normative `:whitespace_adjacency` diff.
 
 The cascade behaviour was reported in
 https://github.com/lutaml/canon/issues/137[issue #137]. The fix landed
-as a report-only re-alignment in PR #138.
+as a report-only re-alignment in PR #138. PR #141 replaced the
+misleading `:surrounding`/`:preceding`/`:following` position labels
+with direction-faithful wording (`before`/`after`/`adjacent to`).

--- a/lib/canon/comparison/xml_comparator.rb
+++ b/lib/canon/comparison/xml_comparator.rb
@@ -873,36 +873,39 @@ differences)
             return build_text_diff_reason(text1, text2)
           end
 
-          position = whitespace_adjacency_position(ws_node)
+          direction = whitespace_partner_direction(ws_node)
           ws_vis = visualize_whitespace(ws_text)
           content_vis = content_text ? visualize_whitespace(truncate_text(content_text)) : "(none)"
 
-          "Whitespace #{position} \"#{content_vis}\": " \
+          "Whitespace #{direction} \"#{content_vis}\": " \
             "present on #{present_side} (\"#{ws_vis}\"), absent on #{absent_side}"
         end
 
-        def whitespace_adjacency_position(ws_node)
-          return :isolated unless ws_node.is_a?(Canon::Xml::Node) ||
+        # Direction of the partner content relative to the whitespace node,
+        # phrased from the partner's point of view: "before" when the
+        # whitespace immediately precedes its next non-whitespace sibling
+        # (the alignment partner on the other side), "after" when the
+        # whitespace trails the previous non-whitespace sibling, or
+        # "adjacent to" as a degenerate fallback when neither neighbour
+        # exists.
+        def whitespace_partner_direction(ws_node)
+          return "adjacent to" unless ws_node.is_a?(Canon::Xml::Node) ||
             ws_node.is_a?(Nokogiri::XML::Node)
 
           parent = ws_node.parent
-          return :isolated if parent.nil?
+          return "adjacent to" if parent.nil?
 
           siblings = parent.children
           idx = siblings.index(ws_node)
-          return :isolated unless idx
+          return "adjacent to" unless idx
 
-          before = sibling_with_content?(siblings, idx, -1)
-          after = sibling_with_content?(siblings, idx, 1)
-
-          if before && after then :surrounding
-          elsif before then :following
-          elsif after then :preceding
-          else :isolated
+          if non_ws_sibling_exists?(siblings, idx, 1) then "before"
+          elsif non_ws_sibling_exists?(siblings, idx, -1) then "after"
+          else "adjacent to"
           end
         end
 
-        def sibling_with_content?(siblings, idx, direction)
+        def non_ws_sibling_exists?(siblings, idx, direction)
           i = idx + direction
           while i >= 0 && i < siblings.length
             s = siblings[i]

--- a/spec/canon/comparison/whitespace_adjacency_spec.rb
+++ b/spec/canon/comparison/whitespace_adjacency_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe ":whitespace_adjacency diff dimension (#137)" do
       bad_pairs = result.differences.select do |d|
         next false unless d.dimension == :text_content
 
-        n1_text = node_text_for(d.respond_to?(:node1) ? d.node1 : nil)
-        n2_text = node_text_for(d.respond_to?(:node2) ? d.node2 : nil)
+        n1_text = node_text_for(d.node1)
+        n2_text = node_text_for(d.node2)
         next false unless n1_text && n2_text
 
         (n1_text.strip.empty? && !n2_text.strip.empty?) ||
@@ -110,27 +110,34 @@ RSpec.describe ":whitespace_adjacency diff dimension (#137)" do
     end
 
     it "says 'after' when the whitespace trails the partner at parent edge" do
-      # Asymmetric whitespace after the last content sibling — no
-      # non-whitespace sibling exists after the whitespace node, so the
-      # partner sits before it.
-      html1 = "<a><span>ISO </span><span>712</span>\n   </a>"
-      html2 = "<a><span>ISO </span><span>712</span></a>"
+      # Trailing whitespace inside a whitespace-preserving element (<code>)
+      # paired against an extra element on the other side.  The whitespace
+      # has a backward non-ws sibling (<b>A</b>) but no forward non-ws
+      # sibling, so the direction is "after".
+      html1 = "<code><b>A</b>\n</code>"
+      html2 = "<code><b>A</b><b>B</b></code>"
 
-      reason = reason_for(html1, html2)
-      # The trailing whitespace may or may not survive the upstream
-      # pretty-print filter; only assert when a :whitespace_adjacency
-      # diff actually surfaces.
-      expect(reason).to include('Whitespace after "712"') unless reason.empty?
+      expect(reason_for(html1, html2)).to include('Whitespace after "B"')
+    end
+
+    it "says 'adjacent to' when the whitespace has no non-ws siblings" do
+      # A whitespace-only text node as the sole child of a
+      # whitespace-preserving element, paired against content on the
+      # other side.  No non-ws siblings in either direction.
+      html1 = "<code>\n</code>"
+      html2 = "<code><b>A</b></code>"
+
+      expect(reason_for(html1, html2)).to include('Whitespace adjacent to "A"')
     end
   end
 
   def node_text_for(node)
     return nil if node.nil?
 
-    if node.respond_to?(:value) && !node.respond_to?(:element?)
-      node.value.to_s
-    elsif node.respond_to?(:content)
-      node.content.to_s
+    case node
+    when Canon::Xml::Nodes::TextNode then node.value.to_s
+    when Canon::Xml::Node then node.value.to_s
+    when Nokogiri::XML::Node then node.content.to_s
     end
   end
 end

--- a/spec/canon/comparison/whitespace_adjacency_spec.rb
+++ b/spec/canon/comparison/whitespace_adjacency_spec.rb
@@ -79,6 +79,51 @@ RSpec.describe ":whitespace_adjacency diff dimension (#137)" do
     end
   end
 
+  # Direction wording in the Reason line names where the partner content
+  # sits relative to the whitespace node — "before" when the whitespace
+  # immediately precedes the next non-whitespace sibling (the alignment
+  # partner on the other side), "after" at the trailing edge of a parent.
+  #
+  # The earlier `surrounding`/`preceding`/`following` wording was
+  # misleading: it described the whitespace node's position among its own
+  # siblings rather than its direction relative to the partner — so a
+  # whitespace node sandwiched between two spans, with only the leading
+  # gap asymmetric, was reported as "surrounding" the partner. See the
+  # #137 follow-up.
+  context "direction wording in the Reason line" do
+    def reason_for(html1, html2)
+      result = Canon::Comparison.equivalent?(
+        html1, html2, format: :html5, verbose: true
+      )
+      diff = result.differences.find { |d| d.dimension == :whitespace_adjacency }
+      diff&.reason.to_s
+    end
+
+    it "says 'before' when the whitespace precedes the partner" do
+      # Asymmetric whitespace between two spans — the partner on the
+      # actual side aligns with the second span ("712"), and the
+      # whitespace sits immediately before it on the expected side.
+      html1 = "<a><span>ISO </span>\n   <span>712</span></a>"
+      html2 = "<a><span>ISO </span><span>712</span></a>"
+
+      expect(reason_for(html1, html2)).to include('Whitespace before "712"')
+    end
+
+    it "says 'after' when the whitespace trails the partner at parent edge" do
+      # Asymmetric whitespace after the last content sibling — no
+      # non-whitespace sibling exists after the whitespace node, so the
+      # partner sits before it.
+      html1 = "<a><span>ISO </span><span>712</span>\n   </a>"
+      html2 = "<a><span>ISO </span><span>712</span></a>"
+
+      reason = reason_for(html1, html2)
+      # The trailing whitespace may or may not survive the upstream
+      # pretty-print filter; only assert when a :whitespace_adjacency
+      # diff actually surfaces.
+      expect(reason).to include('Whitespace after "712"') unless reason.empty?
+    end
+  end
+
   def node_text_for(node)
     return nil if node.nil?
 


### PR DESCRIPTION
## Summary

Follow-up to #137 / #138: the `:whitespace_adjacency` Reason line was misleading because it spliced two **independently computed** values together as if they described one relationship.

- `whitespace_adjacency_position(ws_node)` classified where the whitespace node sat among **its own siblings** (`:surrounding` / `:preceding` / `:following` / `:isolated`).
- `content_vis` was the text of the **partner cursor** the whitespace was zipped against.

Reading "Whitespace surrounding 712" naturally implies whitespace wraps 712 on both sides. In mixed-content cases like

```html
<a href="#ISO712">
  <span class="stdpublisher">ISO </span>
  <span class="stddocNumber">712</span>，
  <span class="citetbl">表1〜1</span>
</a>
```

only the **leading** whitespace (between `</span>ISO ` and `<span>712`) is asymmetric. Removing only that gap clears the diff — but the message implied both sides mattered. Spotted in `metanorma-iso spec/isodoc/i18n_spec.rb:2002`.

## Fix (option 2: direction-faithful wording)

Replace `whitespace_adjacency_position` with `whitespace_partner_direction(ws_node)`. The alignment walk only emits this dimension when the ws cursor advances past a content partner on the other side, so the partner content always corresponds to the ws node's **next** (or, at parent edge, **previous**) non-ws sibling on the ws side. Direction can therefore be derived locally — no extra parameter threaded through `add_difference`.

New Reason wording:

- `Whitespace before "<partner>"` — common case; ws immediately precedes the partner.
- `Whitespace after "<partner>"` — trailing edge of a parent.
- `Whitespace adjacent to "<partner>"` — degenerate fallback.

Internal `:surrounding` / `:preceding` / `:following` classifier deleted (no other callers; matches PR #140's "no dead helpers" spirit).

Architectural alignment with PR #140: type questions still go through `NodeInspector` (`text_node?`, `text_content`). No `respond_to?` / `send` reintroduced. No new dispatch-shaped plumbing.

## Future work (option 3, deferred)

A more informative phrasing would name **both** neighbours: `Whitespace between "<prev>" and "<next>"`. That changes every `:whitespace_adjacency` line and is longer; defer until there is feedback that "before" / "after" alone remains ambiguous in practice.

## Test plan
- [x] `bundle exec rspec` — 2183 examples, 0 failures, 1 pending (pre-existing)
- [x] `bundle exec rubocop` on changed files — 0 offences
- [x] New direction-case specs in `spec/canon/comparison/whitespace_adjacency_spec.rb` cover `before` and `after`
- [ ] Downstream: re-run `metanorma-iso spec/isodoc/i18n_spec.rb:2002` against this branch and confirm the Reason line now reads `Whitespace before "712": present on EXPECTED ...` (verdict unchanged — still non-equivalent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
